### PR TITLE
[DOC] link architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,5 @@ For more advanced features, see `doc/spinalHDL.html`.
 
 See `doc/hello_world.md` for a minimal boot example that sends a
 "hello world" string over a link using newly supported instructions.
+An overview of the link services and the upcoming VCP design lives in
+`doc/link_architecture.md`.

--- a/doc/hello_world.md
+++ b/doc/hello_world.md
@@ -19,3 +19,6 @@ stream ID and length, followed by the string bytes.
 
 The code makes use of several of the newly implemented operations such
 as `ldpi`, `outbyte`, `outword`, `lb`, `dup` and `pop`.
+
+See `link_architecture.md` for details on how the channel services and
+future VCP will interact with memory.

--- a/doc/link_architecture.md
+++ b/doc/link_architecture.md
@@ -1,0 +1,42 @@
+# Link Architecture
+
+This note collects information about the current link interface and future VCP integration.
+
+## ChannelPlugin
+
+`ChannelPlugin` exposes link I/O through two small services:
+
+- `ChannelPinsSrv` – yields a `ChannelPins` bundle for the top‑level RTL.
+- `ChannelSrv` – provides `rx` and `tx` `Stream[Bits]` vectors used inside the CPU.
+
+Each link is buffered by a pair of two‑word FIFOs. Other plugins see clean
+`Stream` endpoints and do not worry about pin timing.
+
+## Memory handshake via `LinkBusSrv`
+
+`MemoryPlugin` implements a third bus service named `LinkBusSrv`.  It mirrors the
+regular data bus but is reserved for link DMA and VCP traffic.  Plugins issue
+`MemReadCmd` and `MemWriteCmd` requests on this service and receive responses in
+`rdRsp` and `wrCmd` streams.  The address space exposes the link input/output
+registers defined in `TConsts` (e.g. `Link0Output`, `Link0Input`).
+
+## T9000 VCP design
+
+The T9000 used a small virtual channel processor (VCP) to move packets between
+the links and memory.  In this project a future `VcpPlugin` will implement that
+logic as yet another `FiberPlugin`.  It will subscribe to `ChannelSrv` for raw
+words and use `LinkBusSrv` to fetch or store packet payloads.  Expected register
+usage follows the classic INMOS scheme: the link output registers accept command
+words while the input registers deliver completed messages.
+
+### Integration points
+
+A `VcpPlugin` would plug into:
+
+- `ChannelSrv` for the physical link streams;
+- `LinkBusSrv` for memory access to the per‑link input/output registers;
+- optionally `SchedSrv` and `TimerSrv` when scheduling packets.
+
+The plugin processes messages such as `OPEN_CHANNEL`, `DATA`, and `CLOSE` using
+these services and updates the RAM locations from `TConsts.Link0Input` upward.
+


### PR DESCRIPTION
### What & Why
* Document link services and upcoming VCP design.
* Added new doc/link_architecture.md and cross‑references.

### Validation
- [x] `sbt scalafmtAll`
- [x] `sbt test`
- [x] `sbt "runMain t800.TopVerilog --variant=min"` *(fails: ASSIGNMENT OVERLAP)*
- [x] `sbt "runMain t800.TopVerilog --variant=full"` *(fails: ASSIGNMENT OVERLAP)*

------
https://chatgpt.com/codex/tasks/task_e_684bee2536888325860875ae2b403d04