### PR TITLE
Refactor ChannelSrv

### DIFF
--- a/src/main/scala/t800/plugins/ChannelPlugin.scala
+++ b/src/main/scala/t800/plugins/ChannelPlugin.scala
@@ -2,7 +2,7 @@ package t800.plugins
 
 import spinal.core._
 import spinal.lib._
-import t800.{MemReadCmd, MemWriteCmd, TConsts}
+import t800.TConsts
 
 /** Provides transputer link interfaces with simple FIFO synchronizers. */
 class ChannelPlugin extends FiberPlugin {
@@ -16,9 +16,17 @@ class ChannelPlugin extends FiberPlugin {
     txVec = Vec.fill(TConsts.LinkCount)(Stream(Bits(TConsts.WordBits bits)))
     rxVec.foreach(_.setIdle())
     txVec.foreach(_.setIdle())
+    rxVec.foreach(_.ready := False)
     addService(new ChannelSrv {
-      override def rx: Vec[Stream[Bits]] = rxVec
-      override def tx: Vec[Stream[Bits]] = txVec
+      override def txReady(link: UInt): Bool = txVec(link).ready
+      override def push(link: UInt, data: Bits): Bool = {
+        txVec(link).valid := True
+        txVec(link).payload := data
+        txVec(link).ready
+      }
+      override def rxValid(link: UInt): Bool = rxVec(link).valid
+      override def rxPayload(link: UInt): Bits = rxVec(link).payload
+      override def rxAck(link: UInt): Unit = { rxVec(link).ready := True }
     })
     addService(new ChannelPinsSrv { def pins = ChannelPlugin.this.pins })
   }

--- a/src/main/scala/t800/plugins/ExecutePlugin.scala
+++ b/src/main/scala/t800/plugins/ExecutePlugin.scala
@@ -29,14 +29,14 @@ class ExecutePlugin extends FiberPlugin {
     val mem = Plugin[DataBusSrv]
     val timer = Plugin[TimerSrv]
     val linksOpt = Try(Plugin[ChannelSrv]).toOption
-    val dummyRx = Vec.fill(TConsts.LinkCount)(Stream(Bits(TConsts.WordBits bits)))
-    val dummyTx = Vec.fill(TConsts.LinkCount)(Stream(Bits(TConsts.WordBits bits)))
-    dummyRx.foreach(_.setIdle())
-    dummyTx.foreach(_.setIdle())
-    val links = linksOpt.getOrElse(new ChannelSrv {
-      override def rx = dummyRx
-      override def tx = dummyTx
-    })
+    val dummy = new ChannelSrv {
+      override def txReady(link: UInt): Bool = False
+      override def push(link: UInt, data: Bits): Bool = False
+      override def rxValid(link: UInt): Bool = False
+      override def rxPayload(link: UInt): Bits = B(0, TConsts.WordBits bits)
+      override def rxAck(link: UInt): Unit = {}
+    }
+    val links = linksOpt.getOrElse(dummy)
     val sched = Plugin[SchedSrv]
 
     val inst = pipe.execute(pipe.INSTR)
@@ -52,9 +52,6 @@ class ExecutePlugin extends FiberPlugin {
     sched.newProc.valid := False
     sched.newProc.payload.ptr := U(0)
     sched.newProc.payload.high := False
-
-    links.rx.foreach(_.ready := False)
-    links.tx.foreach(_.valid := False)
 
     switch(primary) {
       is(Opcodes.Primary.PFIX) {
@@ -79,18 +76,17 @@ class ExecutePlugin extends FiberPlugin {
           }
           is(Opcodes.Secondary.IN) {
             val idx = stack.B(1 downto 0)
-            links.rx(idx).ready := False
-            pipe.execute.haltWhen(!links.rx(idx).valid)
+            val avail = links.rxValid(idx)
+            pipe.execute.haltWhen(!avail)
             when(pipe.execute.down.isFiring) {
-              stack.A := links.rx(idx).payload.asUInt
-              links.rx(idx).ready := True
+              stack.A := links.rxPayload(idx).asUInt
+              links.rxAck(idx)
             }
           }
           is(Opcodes.Secondary.OUT) {
             val idx = stack.B(1 downto 0)
-            links.tx(idx).valid := True
-            links.tx(idx).payload := stack.A.asBits
-            pipe.execute.haltWhen(!links.tx(idx).ready)
+            val ready = links.push(idx, stack.A.asBits)
+            pipe.execute.haltWhen(!ready)
             when(pipe.execute.down.isFiring) {
               stack.A := stack.B
               stack.B := stack.C
@@ -192,9 +188,8 @@ class ExecutePlugin extends FiberPlugin {
           }
           is(Opcodes.Secondary.OUTBYTE) {
             val idx = stack.B(1 downto 0)
-            links.tx(idx).valid := True
-            links.tx(idx).payload := stack.A.asBits
-            pipe.execute.haltWhen(!links.tx(idx).ready)
+            val ready = links.push(idx, stack.A.asBits)
+            pipe.execute.haltWhen(!ready)
             when(pipe.execute.down.isFiring) {
               stack.A := stack.B
               stack.B := stack.C
@@ -202,9 +197,8 @@ class ExecutePlugin extends FiberPlugin {
           }
           is(Opcodes.Secondary.OUTWORD) {
             val idx = stack.B(1 downto 0)
-            links.tx(idx).valid := True
-            links.tx(idx).payload := stack.A.asBits
-            pipe.execute.haltWhen(!links.tx(idx).ready)
+            val ready = links.push(idx, stack.A.asBits)
+            pipe.execute.haltWhen(!ready)
             when(pipe.execute.down.isFiring) {
               stack.A := stack.B
               stack.B := stack.C

--- a/src/main/scala/t800/plugins/Services.scala
+++ b/src/main/scala/t800/plugins/Services.scala
@@ -67,8 +67,21 @@ case class ChannelPins(count: Int) extends Bundle with LinkPins {
 }
 
 trait ChannelSrv {
-  def rx: Vec[Stream[Bits]]
-  def tx: Vec[Stream[Bits]]
+
+  /** Return true when the transmit FIFO can accept a new word. */
+  def txReady(link: UInt): Bool
+
+  /** Drive a transmit request. The returned value mirrors txReady. */
+  def push(link: UInt, data: Bits): Bool
+
+  /** True when a word is available on the receive FIFO. */
+  def rxValid(link: UInt): Bool
+
+  /** Current word from the receive FIFO. */
+  def rxPayload(link: UInt): Bits
+
+  /** Acknowledge the current word when done. */
+  def rxAck(link: UInt): Unit
 }
 
 trait ChannelPinsSrv {


### PR DESCRIPTION
### What & Why
* plugins now issue channel requests via methods instead of directly driving the streams
* ExecutePlugin updated to use new push/pop helpers

### Validation
- [x] `sbt scalafmtAll`
- [x] `sbt test`
- [ ] `sbt "runMain t800.TopVerilog --variant=min"`
- [ ] `sbt "runMain t800.TopVerilog --variant=full"`

Both Verilog generation commands failed with 'NO DRIVER' errors in the SpinalHDL checks.


------
https://chatgpt.com/codex/tasks/task_e_684bee168ccc8325839eada1110946ef