### PR TITLE
docs: add sim speed printer tip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,8 @@ details.
 * Use `fork { ... }` to spawn concurrent threads. Control time with `sleep(n)`
   and block on conditions via `waitUntil(expr)` or the ClockDomain helpers
   like `waitRisingEdge()`.
+* Call `clockDomain.forkSimSpeedPrinter(printPeriod)` to print the current
+  simulation speed. See `doc/spinalHDL.html` for details.
 
 #### Common runtime errors
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ record only a short window before the crash.
 Spawn helper threads with `fork { ... }` and block on events using `sleep(n)` or
 `waitUntil(cond)`. ClockDomain utilities such as `waitRisingEdge()` help align
 checks with clock boundaries. See **AGENTS.md §12** for common runtime errors.
+* `clockDomain.forkSimSpeedPrinter(printPeriod)` prints the simulation speed;
+  see `doc/spinalHDL.html` for details.
 
 See `doc/hello_world.md` for a quick overview, and `doc/helloworld.md` for the full source listing.
 `HelloWorldSpec` is currently marked with `ignore` until the channel hardware is complete.


### PR DESCRIPTION
### What & Why
* Documented `forkSimSpeedPrinter()` usage in simulation guides.

### Validation
- [x] `sbt scalafmtAll`
- [x] `sbt test`
- [x] `sbt "runMain t800.TopVerilog"`


------
https://chatgpt.com/codex/tasks/task_e_684bf194ca208325ad2b8073e2211d1b