### PR TITLE
Add MIT license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 t800 contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -187,3 +187,9 @@ checks with clock boundaries. See **AGENTS.md §12** for common runtime errors.
 
 See `doc/hello_world.md` for a quick overview, and `doc/helloworld.md` for the full source listing.
 `HelloWorldSpec` is currently marked with `ignore` until the channel hardware is complete.
+
+---
+
+## License
+
+This project is released under the [MIT License](LICENSE).


### PR DESCRIPTION
### What & Why
* Added LICENSE file with MIT license.
* Documented license in README.

### Validation
- [x] `sbt scalafmtAll`
- [x] `sbt test`
- [x] `sbt "runMain t800.TopVerilog"`


------
https://chatgpt.com/codex/tasks/task_e_684bf54bfe9c8325a25c7878f5877d43