### PR TITLE
Use Database for plugin config

### DIFF
--- a/src/main/scala/t800/Database.scala
+++ b/src/main/scala/t800/Database.scala
@@ -1,0 +1,61 @@
+package t800
+
+import scala.collection.mutable
+import spinal.core._
+import spinal.core.fiber.Handle
+
+/** Simple thread-local key/value store used for global configuration. */
+class Database {
+  // user API
+  def update[T](key: Database.Element[T], value: T): Unit = key.set(this, value)
+  def apply[T](key: Database.Element[T]): T = key.get(this)
+
+  // internal storage
+  private val storage = mutable.LinkedHashMap[Database.Element[_ <: Any], Any]()
+  def storageUpdate[T](key: Database.Element[T], value: T): Unit = storage.update(key, value)
+  def storageGet[T](key: Database.Element[T]): T = storage(key).asInstanceOf[T]
+  def storageGetElseUpdate[T](key: Database.Element[T], create: => T): T =
+    storage.getOrElseUpdate(key, create).asInstanceOf[T]
+  def storageExists[T](key: Database.Element[T]): Boolean = storage.contains(key)
+}
+
+object Database extends ScopeProperty[Database] {
+  def on[T](body: => T): T = this(new Database).on(body)
+  def value[T](): Database.ElementValue[T] = new ElementValue[T]()
+  def blocking[T](): Database.ElementBlocking[T] = new ElementBlocking[T]()
+  def landa[T](body: => T): Database.ElementLanda[T] = new ElementLanda[T](body)
+
+  abstract class Element[T](sp: ScopeProperty[Database] = Database) extends Nameable {
+    def get(): T = get(sp.get)
+    def apply(): T = get(sp.get)
+    def set(value: T): Unit = set(sp.get, value)
+    def get(db: Database): T
+    def set(db: Database, value: T): Unit
+  }
+  class ElementValue[T](sp: ScopeProperty[Database] = Database) extends Element[T](sp) {
+    def get(db: Database): T = db.storageGet(this)
+    def set(db: Database, value: T): Unit = db.storageUpdate(this, value)
+  }
+  class ElementBlocking[T](sp: ScopeProperty[Database] = Database)
+      extends Element[T](sp)
+      with Area {
+    private val thing = new ElementValue[Handle[T]]()
+    def getHandle(db: Database): Handle[T] =
+      db.storageGetElseUpdate(thing, new Handle[T].setCompositeName(this))
+    def get(db: Database): T = getHandle(db).get
+    def set(db: Database, value: T): Unit = {
+      assert(!getHandle(db).isLoaded)
+      getHandle(db).load(value)
+    }
+  }
+  class ElementLanda[T](body: => T, sp: ScopeProperty[Database] = Database)
+      extends ElementValue[T](sp) {
+    override def get(db: Database): T = {
+      if (!db.storageExists(this)) {
+        db.storageUpdate(this, body)
+      }
+      super.get(db)
+    }
+    override def set(db: Database, value: T): Unit = ???
+  }
+}

--- a/src/main/scala/t800/Global.scala
+++ b/src/main/scala/t800/Global.scala
@@ -1,0 +1,15 @@
+package t800
+
+import spinal.core._
+
+/** Global configuration elements accessed via [[Database]]. Plugins should use these handles rather
+  * than constants in [[TConsts]].
+  */
+object Global extends AreaObject {
+  val WORD_BITS = Database.blocking[Int]
+  val ADDR_BITS = Database.blocking[Int]
+  val ROM_WORDS = Database.blocking[Int]
+  val RAM_WORDS = Database.blocking[Int]
+  val LINK_COUNT = Database.blocking[Int]
+  val RESET_PC = Database.blocking[Long]
+}

--- a/src/main/scala/t800/MemPort.scala
+++ b/src/main/scala/t800/MemPort.scala
@@ -4,10 +4,10 @@ import spinal.core._
 
 /** Generic memory port command definitions. */
 case class MemReadCmd() extends Bundle {
-  val addr = UInt(TConsts.AddrBits bits)
+  val addr = UInt(Global.ADDR_BITS() bits)
 }
 
 case class MemWriteCmd() extends Bundle {
-  val addr = UInt(TConsts.AddrBits bits)
-  val data = Bits(TConsts.WordBits bits)
+  val addr = UInt(Global.ADDR_BITS() bits)
+  val data = Bits(Global.WORD_BITS() bits)
 }

--- a/src/main/scala/t800/T800Core.scala
+++ b/src/main/scala/t800/T800Core.scala
@@ -3,9 +3,27 @@ package t800
 import spinal.core._
 import t800.plugins._
 
-class T800(plugins: Seq[FiberPlugin]) extends Component {
+object T800 {
+
+  /** Create a database pre-loaded with defaults from [[TConsts]]. */
+  def defaultDatabase(): Database = {
+    val db = new Database
+    db(Global.WORD_BITS) = TConsts.WordBits
+    db(Global.ADDR_BITS) = TConsts.AddrBits
+    db(Global.ROM_WORDS) = TConsts.RomWords
+    db(Global.RAM_WORDS) = TConsts.RamWords
+    db(Global.LINK_COUNT) = TConsts.LinkCount
+    db(Global.RESET_PC) = TConsts.ResetPC
+    db
+  }
+}
+
+class T800(plugins: Seq[FiberPlugin], database: Database = T800.defaultDatabase())
+    extends Component {
   val host = new PluginHost
-  host.asHostOf(plugins)
+  Database(database).on {
+    host.asHostOf(plugins)
+  }
 }
 
 class T800Core

--- a/src/main/scala/t800/Top.scala
+++ b/src/main/scala/t800/Top.scala
@@ -18,6 +18,7 @@ object TopVerilog {
       new TimerPlugin
     )
 
-    SpinalVerilog(new T800(plugins))
+    val db = T800.defaultDatabase()
+    SpinalVerilog(new T800(plugins, db))
   }
 }

--- a/src/main/scala/t800/plugins/ChannelPlugin.scala
+++ b/src/main/scala/t800/plugins/ChannelPlugin.scala
@@ -2,7 +2,7 @@ package t800.plugins
 
 import spinal.core._
 import spinal.lib._
-import t800.TConsts
+import t800.Global
 
 /** Provides transputer link interfaces with simple FIFO synchronizers. */
 class ChannelPlugin extends FiberPlugin {
@@ -14,14 +14,14 @@ class ChannelPlugin extends FiberPlugin {
   private var memTx: Vec[Stream[Bits]] = null
 
   override def setup(): Unit = {
-    pins = ChannelPins(TConsts.LinkCount)
-    rxVec = Vec.fill(TConsts.LinkCount)(Stream(Bits(TConsts.WordBits bits)))
-    txVec = Vec.fill(TConsts.LinkCount)(Stream(Bits(TConsts.WordBits bits)))
+    pins = ChannelPins(Global.LINK_COUNT())
+    rxVec = Vec.fill(Global.LINK_COUNT())(Stream(Bits(Global.WORD_BITS() bits)))
+    txVec = Vec.fill(Global.LINK_COUNT())(Stream(Bits(Global.WORD_BITS() bits)))
     rxVec.foreach(_.setIdle())
     txVec.foreach(_.setIdle())
     rxVec.foreach(_.ready := False)
     cmdStream = Stream(ChannelTxCmd()).setIdle()
-    busyVec = Vec.fill(TConsts.LinkCount)(Reg(Bool()) init False)
+    busyVec = Vec.fill(Global.LINK_COUNT())(Reg(Bool()) init False)
     addService(new ChannelSrv {
       override def txReady(link: UInt): Bool = txVec(link).ready
       override def push(link: UInt, data: Bits): Bool = {
@@ -40,19 +40,19 @@ class ChannelPlugin extends FiberPlugin {
     implicit val h: PluginHost = host
     val mem = Plugin[LinkBusSrv]
 
-    memTx = Vec.fill(TConsts.LinkCount)(Stream(Bits(TConsts.WordBits bits)))
+    memTx = Vec.fill(Global.LINK_COUNT())(Stream(Bits(Global.WORD_BITS() bits)))
     memTx.foreach(_.setIdle())
 
-    for (i <- 0 until TConsts.LinkCount) {
+    for (i <- 0 until Global.LINK_COUNT()) {
       rxVec(i) << pins.in(i)
       val arb = StreamArbiterFactory.lowerFirst.onArgs(txVec(i), memTx(i))
       pins.out(i) << arb
     }
 
     cmdStream.ready := !busyVec.reduce(_ || _)
-    val ptr = Reg(UInt(TConsts.AddrBits bits)) init 0
-    val remaining = Reg(UInt(TConsts.AddrBits bits)) init 0
-    val linkIdx = Reg(UInt(log2Up(TConsts.LinkCount) bits)) init 0
+    val ptr = Reg(UInt(Global.ADDR_BITS() bits)) init 0
+    val remaining = Reg(UInt(Global.ADDR_BITS() bits)) init 0
+    val linkIdx = Reg(UInt(log2Up(Global.LINK_COUNT()) bits)) init 0
     val haveByte = Reg(Bool()) init False
     val byteReg = Reg(Bits(8 bits)) init 0
 

--- a/src/main/scala/t800/plugins/DecodeExecutePlugin.scala
+++ b/src/main/scala/t800/plugins/DecodeExecutePlugin.scala
@@ -3,7 +3,6 @@ package t800.plugins
 import spinal.core._
 import spinal.lib._
 import t800.plugins._
-import t800.TConsts
 
 class DecodeExecutePlugin extends FiberPlugin {
   val ctrl = Flow(UInt(8 bits))

--- a/src/main/scala/t800/plugins/ExecutePlugin.scala
+++ b/src/main/scala/t800/plugins/ExecutePlugin.scala
@@ -3,7 +3,7 @@ package t800.plugins
 import spinal.core._
 import spinal.lib._
 import spinal.lib.misc.pipeline._
-import t800.{Opcodes, TConsts}
+import t800.{Opcodes, Global}
 import t800.plugins.{ChannelSrv, DataBusSrv, SchedSrv, ChannelTxCmd}
 import scala.util.Try
 
@@ -16,10 +16,10 @@ class ExecutePlugin extends FiberPlugin {
   override def setup(): Unit = {
     errReg = Reg(Bool()) init (False)
     haltErr = Reg(Bool()) init (False)
-    hiFPtr = Reg(UInt(TConsts.WordBits bits)) init (0)
-    hiBPtr = Reg(UInt(TConsts.WordBits bits)) init (0)
-    loFPtr = Reg(UInt(TConsts.WordBits bits)) init (0)
-    loBPtr = Reg(UInt(TConsts.WordBits bits)) init (0)
+    hiFPtr = Reg(UInt(Global.WORD_BITS() bits)) init (0)
+    hiBPtr = Reg(UInt(Global.WORD_BITS() bits)) init (0)
+    loFPtr = Reg(UInt(Global.WORD_BITS() bits)) init (0)
+    loBPtr = Reg(UInt(Global.WORD_BITS() bits)) init (0)
   }
 
   override def build(): Unit = {
@@ -34,7 +34,7 @@ class ExecutePlugin extends FiberPlugin {
       override def txReady(link: UInt): Bool = False
       override def push(link: UInt, data: Bits): Bool = False
       override def rxValid(link: UInt): Bool = False
-      override def rxPayload(link: UInt): Bits = B(0, TConsts.WordBits bits)
+      override def rxPayload(link: UInt): Bits = B(0, Global.WORD_BITS() bits)
       override def rxAck(link: UInt): Unit = {}
     }
     val links = linksOpt.getOrElse(dummy)
@@ -49,7 +49,7 @@ class ExecutePlugin extends FiberPlugin {
     mem.rdCmd.payload.addr := U(0)
     mem.wrCmd.valid := False
     mem.wrCmd.payload.addr := U(0)
-    mem.wrCmd.payload.data := B(0, TConsts.WordBits bits)
+    mem.wrCmd.payload.data := B(0, Global.WORD_BITS() bits)
     sched.newProc.valid := False
     sched.newProc.payload.ptr := U(0)
     sched.newProc.payload.high := False
@@ -221,7 +221,7 @@ class ExecutePlugin extends FiberPlugin {
             when(pipe.execute.down.isFiring) {
               val shift = addr(1 downto 0) * 8
               val byte = (mem.rdRsp.payload >> shift).resize(8)
-              stack.A := byte.asUInt.resize(TConsts.WordBits)
+              stack.A := byte.asUInt.resize(Global.WORD_BITS())
             }
           }
           is(Opcodes.Secondary.OUTBYTE) {

--- a/src/main/scala/t800/plugins/FetchPlugin.scala
+++ b/src/main/scala/t800/plugins/FetchPlugin.scala
@@ -2,7 +2,6 @@ package t800.plugins
 
 import spinal.core._
 import spinal.lib._
-import t800.TConsts
 
 /** Instruction fetch unit using the pipeline framework. */
 class FetchPlugin extends FiberPlugin {

--- a/src/main/scala/t800/plugins/FpuPlugin.scala
+++ b/src/main/scala/t800/plugins/FpuPlugin.scala
@@ -5,12 +5,12 @@ import spinal.lib._
 
 import spinal.lib.misc.pipeline._
 import t800.plugins._
-import t800.TConsts
+import t800.Global
 
 class FpCmd(opBits: Int = 3) extends Bundle {
   val op = Bits(opBits bits)
-  val opa = UInt(TConsts.WordBits bits)
-  val opb = UInt(TConsts.WordBits bits)
+  val opa = UInt(Global.WORD_BITS() bits)
+  val opb = UInt(Global.WORD_BITS() bits)
   def this(name: String, a: UInt, b: UInt) = {
     this()
     name match {
@@ -31,7 +31,7 @@ class FpuPlugin extends FiberPlugin {
 
   override def setup(): Unit = {
     pipeReg = Flow(new FpCmd)
-    rspReg = Flow(UInt(TConsts.WordBits bits))
+    rspReg = Flow(UInt(Global.WORD_BITS() bits))
     addService(new FpuSrv {
       override def pipe = pipeReg
       override def rsp = rspReg
@@ -49,7 +49,7 @@ class FpuPlugin extends FiberPlugin {
     val A = n0.insert(pipeReg.payload.opa)
     val B = n0.insert(pipeReg.payload.opb)
 
-    val resultCalc = UInt(TConsts.WordBits bits)
+    val resultCalc = UInt(Global.WORD_BITS() bits)
     switch(n1(OP)) {
       is(B"000") { resultCalc := (n1(A) + n1(B)).resized }
       is(B"001") { resultCalc := (n1(A) - n1(B)).resized }

--- a/src/main/scala/t800/plugins/MemoryPlugin.scala
+++ b/src/main/scala/t800/plugins/MemoryPlugin.scala
@@ -3,7 +3,7 @@ package t800.plugins
 import spinal.core._
 import spinal.lib._
 import spinal.core.sim._
-import t800.{MemReadCmd, MemWriteCmd, TConsts}
+import t800.{MemReadCmd, MemWriteCmd, TConsts, Global}
 
 /** Simple on-chip memory for instructions. */
 class MemoryPlugin(romInit: Seq[BigInt] = Seq.fill(TConsts.RomWords)(BigInt(0)))
@@ -20,18 +20,18 @@ class MemoryPlugin(romInit: Seq[BigInt] = Seq.fill(TConsts.RomWords)(BigInt(0)))
   private var linkWrCmdReg: Flow[MemWriteCmd] = null
 
   override def setup(): Unit = {
-    rom = Mem(Bits(TConsts.WordBits bits), TConsts.RomWords)
+    rom = Mem(Bits(Global.WORD_BITS() bits), Global.ROM_WORDS())
     rom.initBigInt(romInit)
-    ram = Mem(Bits(TConsts.WordBits bits), TConsts.RamWords)
+    ram = Mem(Bits(Global.WORD_BITS() bits), Global.RAM_WORDS())
     rom.simPublic()
     ram.simPublic()
     instrCmdReg = Flow(MemReadCmd()).setIdle()
-    instrRspReg = Flow(Bits(TConsts.WordBits bits)).setIdle()
+    instrRspReg = Flow(Bits(Global.WORD_BITS() bits)).setIdle()
     dataRdCmdReg = Flow(MemReadCmd()).setIdle()
-    dataRdRspReg = Flow(Bits(TConsts.WordBits bits)).setIdle()
+    dataRdRspReg = Flow(Bits(Global.WORD_BITS() bits)).setIdle()
     dataWrCmdReg = Flow(MemWriteCmd()).setIdle()
     linkRdCmdReg = Flow(MemReadCmd()).setIdle()
-    linkRdRspReg = Flow(Bits(TConsts.WordBits bits)).setIdle()
+    linkRdRspReg = Flow(Bits(Global.WORD_BITS() bits)).setIdle()
     linkWrCmdReg = Flow(MemWriteCmd()).setIdle()
     addService(new InstrBusSrv {
       override def cmd = instrCmdReg
@@ -55,26 +55,26 @@ class MemoryPlugin(romInit: Seq[BigInt] = Seq.fill(TConsts.RomWords)(BigInt(0)))
 
   override def build(): Unit = {
     instrRspReg.payload := rom.readSync(
-      instrCmdReg.payload.addr(log2Up(TConsts.RomWords) - 1 downto 0)
+      instrCmdReg.payload.addr(log2Up(Global.ROM_WORDS()) - 1 downto 0)
     )
     instrRspReg.valid := instrCmdReg.valid
     dataRdRspReg.payload := ram.readSync(
-      dataRdCmdReg.payload.addr(log2Up(TConsts.RamWords) - 1 downto 0)
+      dataRdCmdReg.payload.addr(log2Up(Global.RAM_WORDS()) - 1 downto 0)
     )
     dataRdRspReg.valid := dataRdCmdReg.valid
     linkRdRspReg.payload := ram.readSync(
-      linkRdCmdReg.payload.addr(log2Up(TConsts.RamWords) - 1 downto 0)
+      linkRdCmdReg.payload.addr(log2Up(Global.RAM_WORDS()) - 1 downto 0)
     )
     linkRdRspReg.valid := linkRdCmdReg.valid
     when(dataWrCmdReg.valid) {
       ram.write(
-        dataWrCmdReg.payload.addr(log2Up(TConsts.RamWords) - 1 downto 0),
+        dataWrCmdReg.payload.addr(log2Up(Global.RAM_WORDS()) - 1 downto 0),
         dataWrCmdReg.payload.data
       )
     }
     when(linkWrCmdReg.valid) {
       ram.write(
-        linkWrCmdReg.payload.addr(log2Up(TConsts.RamWords) - 1 downto 0),
+        linkWrCmdReg.payload.addr(log2Up(Global.RAM_WORDS()) - 1 downto 0),
         linkWrCmdReg.payload.data
       )
     }

--- a/src/main/scala/t800/plugins/SchedulerPlugin.scala
+++ b/src/main/scala/t800/plugins/SchedulerPlugin.scala
@@ -2,7 +2,7 @@ package t800.plugins
 
 import spinal.core._
 import spinal.lib._
-import t800.TConsts
+import t800.Global
 
 /** Minimal round-robin scheduler with high/low priority queues. */
 class SchedulerPlugin extends FiberPlugin {
@@ -18,14 +18,14 @@ class SchedulerPlugin extends FiberPlugin {
   override def setup(): Unit = {
     cmdReg = Flow(SchedCmd())
 
-    hiQ = Vec.fill(TConsts.LinkCount)(Reg(UInt(TConsts.AddrBits bits)) init 0)
-    hiHead = Reg(UInt(log2Up(TConsts.LinkCount) bits)) init 0
-    hiTail = Reg(UInt(log2Up(TConsts.LinkCount) bits)) init 0
-    loQ = Vec.fill(TConsts.LinkCount)(Reg(UInt(TConsts.AddrBits bits)) init 0)
-    loHead = Reg(UInt(log2Up(TConsts.LinkCount) bits)) init 0
-    loTail = Reg(UInt(log2Up(TConsts.LinkCount) bits)) init 0
+    hiQ = Vec.fill(Global.LINK_COUNT())(Reg(UInt(Global.ADDR_BITS() bits)) init 0)
+    hiHead = Reg(UInt(log2Up(Global.LINK_COUNT()) bits)) init 0
+    hiTail = Reg(UInt(log2Up(Global.LINK_COUNT()) bits)) init 0
+    loQ = Vec.fill(Global.LINK_COUNT())(Reg(UInt(Global.ADDR_BITS() bits)) init 0)
+    loHead = Reg(UInt(log2Up(Global.LINK_COUNT()) bits)) init 0
+    loTail = Reg(UInt(log2Up(Global.LINK_COUNT()) bits)) init 0
 
-    nextReg = Reg(UInt(TConsts.AddrBits bits)) init 0
+    nextReg = Reg(UInt(Global.ADDR_BITS() bits)) init 0
 
     addService(new SchedSrv {
       override def newProc: Flow[SchedCmd] = cmdReg

--- a/src/main/scala/t800/plugins/Services.scala
+++ b/src/main/scala/t800/plugins/Services.scala
@@ -38,7 +38,7 @@ trait FpuSrv {
 }
 
 case class SchedCmd() extends Bundle {
-  val ptr = UInt(t800.TConsts.AddrBits bits)
+  val ptr = UInt(t800.Global.ADDR_BITS() bits)
   val high = Bool()
 }
 
@@ -91,13 +91,13 @@ trait MemAccessSrv {
 
 case class ChannelTxCmd() extends Bundle {
   val link = UInt(2 bits)
-  val addr = UInt(t800.TConsts.AddrBits bits)
-  val length = UInt(t800.TConsts.AddrBits bits)
+  val addr = UInt(t800.Global.ADDR_BITS() bits)
+  val length = UInt(t800.Global.ADDR_BITS() bits)
 }
 
 case class ChannelPins(count: Int) extends Bundle with LinkPins {
-  val in = Vec(slave Stream (Bits(t800.TConsts.WordBits bits)), count)
-  val out = Vec(master Stream (Bits(t800.TConsts.WordBits bits)), count)
+  val in = Vec(slave Stream (Bits(t800.Global.WORD_BITS() bits)), count)
+  val out = Vec(master Stream (Bits(t800.Global.WORD_BITS() bits)), count)
 }
 
 trait ChannelSrv {

--- a/src/main/scala/t800/plugins/StackPlugin.scala
+++ b/src/main/scala/t800/plugins/StackPlugin.scala
@@ -2,7 +2,7 @@ package t800.plugins
 
 import spinal.core._
 import t800.plugins._
-import t800.TConsts
+import t800.Global
 
 class StackPlugin extends FiberPlugin {
   private var regA: UInt = null
@@ -14,13 +14,13 @@ class StackPlugin extends FiberPlugin {
   private var workspace: Mem[UInt] = null
 
   override def setup(): Unit = {
-    regA = Reg(UInt(TConsts.WordBits bits)) init 0
-    regB = Reg(UInt(TConsts.WordBits bits)) init 0
-    regC = Reg(UInt(TConsts.WordBits bits)) init 0
-    regO = Reg(UInt(TConsts.WordBits bits)) init 0
-    regWPtr = Reg(UInt(TConsts.AddrBits bits)) init 0
-    regIPtr = Reg(UInt(TConsts.AddrBits bits)) init U(TConsts.ResetPC)
-    workspace = Mem(UInt(TConsts.WordBits bits), TConsts.RamWords)
+    regA = Reg(UInt(Global.WORD_BITS() bits)) init 0
+    regB = Reg(UInt(Global.WORD_BITS() bits)) init 0
+    regC = Reg(UInt(Global.WORD_BITS() bits)) init 0
+    regO = Reg(UInt(Global.WORD_BITS() bits)) init 0
+    regWPtr = Reg(UInt(Global.ADDR_BITS() bits)) init 0
+    regIPtr = Reg(UInt(Global.ADDR_BITS() bits)) init U(Global.RESET_PC())
+    workspace = Mem(UInt(Global.WORD_BITS() bits), Global.RAM_WORDS())
 
     addService(new StackSrv {
       override val A: UInt = regA
@@ -30,11 +30,11 @@ class StackPlugin extends FiberPlugin {
       override val WPtr: UInt = regWPtr
       override val IPtr: UInt = regIPtr
       override def read(offset: SInt): UInt = {
-        val addr = (regWPtr.asSInt + offset).asUInt.resize(log2Up(TConsts.RamWords) bits)
+        val addr = (regWPtr.asSInt + offset).asUInt.resize(log2Up(Global.RAM_WORDS()) bits)
         workspace.readSync(addr)
       }
       override def write(offset: SInt, data: UInt): Unit = {
-        val addr = (regWPtr.asSInt + offset).asUInt.resize(log2Up(TConsts.RamWords) bits)
+        val addr = (regWPtr.asSInt + offset).asUInt.resize(log2Up(Global.RAM_WORDS()) bits)
         workspace.write(addr, data)
       }
     })

--- a/src/main/scala/t800/plugins/TimerPlugin.scala
+++ b/src/main/scala/t800/plugins/TimerPlugin.scala
@@ -3,7 +3,7 @@ package t800.plugins
 import spinal.core._
 import spinal.lib._
 import spinal.core.sim._
-import t800.TConsts
+import t800.Global
 
 /** Simple high/low priority timers. High increments every cycle; low every 64 cycles. */
 class TimerPlugin extends FiberPlugin {
@@ -16,11 +16,11 @@ class TimerPlugin extends FiberPlugin {
   private var loEn: Bool = null
 
   override def setup(): Unit = {
-    hiTimer = Reg(UInt(TConsts.WordBits bits)) init (0)
-    loTimer = Reg(UInt(TConsts.WordBits bits)) init (0)
+    hiTimer = Reg(UInt(Global.WORD_BITS() bits)) init (0)
+    loTimer = Reg(UInt(Global.WORD_BITS() bits)) init (0)
     loCnt = Reg(UInt(6 bits)) init (0)
     loadReq = Reg(Bool()) init (False)
-    loadVal = Reg(UInt(TConsts.WordBits bits)) init (0)
+    loadVal = Reg(UInt(Global.WORD_BITS() bits)) init (0)
     hiEn = Reg(Bool()) init (True)
     loEn = Reg(Bool()) init (True)
     hiTimer.simPublic()

--- a/src/test/scala/t800/FpuPluginSpec.scala
+++ b/src/test/scala/t800/FpuPluginSpec.scala
@@ -16,7 +16,10 @@ class FpuDut extends Component {
   }
   val host = new PluginHost
   val plugin = new FpuPlugin
-  host.asHostOf(Seq(plugin))
+  val db = T800.defaultDatabase()
+  Database(db).on {
+    host.asHostOf(Seq(plugin))
+  }
   val srv = host.service[FpuSrv]
   srv.pipe.valid := io.cmdValid
   srv.pipe.payload.op := io.op

--- a/src/test/scala/t800/GlobalDatabaseSpec.scala
+++ b/src/test/scala/t800/GlobalDatabaseSpec.scala
@@ -1,0 +1,25 @@
+package t800
+
+import spinal.core._
+import spinal.core.sim._
+import org.scalatest.funsuite.AnyFunSuite
+import t800.plugins._
+
+class GlobalDatabaseSpec extends AnyFunSuite {
+  test("plugins read configuration from database") {
+    val db = new Database
+    db(Global.WORD_BITS) = 16
+    db(Global.ADDR_BITS) = TConsts.AddrBits
+    db(Global.ROM_WORDS) = TConsts.RomWords
+    db(Global.RAM_WORDS) = TConsts.RamWords
+    db(Global.LINK_COUNT) = TConsts.LinkCount
+    db(Global.RESET_PC) = TConsts.ResetPC
+
+    val plugins = Seq(new TimerPlugin, new TimerProbePlugin)
+    SimConfig.compile(new T800(plugins, db)).doSim { dut =>
+      val probe = dut.host.service[TimerProbeSrv]
+      assert(probe.hi.getWidth == 16)
+      assert(probe.lo.getWidth == 16)
+    }
+  }
+}

--- a/src/test/scala/t800/TimerEnableSpec.scala
+++ b/src/test/scala/t800/TimerEnableSpec.scala
@@ -4,14 +4,17 @@ import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
 import t800.plugins._
+import t800.Global
+
+trait TimerProbeSrv { def hi: UInt; def lo: UInt }
 
 class TimerProbePlugin extends FiberPlugin {
   var hiOut: UInt = null
   var loOut: UInt = null
 
   override def setup(): Unit = {
-    hiOut = out UInt (TConsts.WordBits bits)
-    loOut = out UInt (TConsts.WordBits bits)
+    hiOut = out UInt (Global.WORD_BITS() bits)
+    loOut = out UInt (Global.WORD_BITS() bits)
   }
 
   override def build(): Unit = {
@@ -19,6 +22,7 @@ class TimerProbePlugin extends FiberPlugin {
     val timer = Plugin[TimerSrv]
     hiOut := timer.hi
     loOut := timer.lo
+    addService(new TimerProbeSrv { def hi = hiOut; def lo = loOut })
   }
 }
 


### PR DESCRIPTION
### What & Why
* Centralize configuration via `Global` database handles
* Plugins now obtain widths and sizes from the database
* Added unit test `GlobalDatabaseSpec`

### Validation
- [x] sbt scalafmtAll
- [x] `sbt test` (full + min variants)

------
https://chatgpt.com/codex/tasks/task_e_684c1912cfac8325801040a30d79dbfa