### PR TITLE
[Misc] Vendor DataBase and use DB context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 | Path | Description |
 |------|-------------|
 | `src/main/scala/t800/plugins/` | Each file is a `FiberPlugin` subsystem |
-| `src/main/scala/t800/Top.scala` | Builds the `PluginHost` and plugin list |
+| `src/main/scala/t800/Top.scala` | Builds the `Database` + `PluginHost` and plugin list |
 | `src/test/scala/t800/` | ScalaTest units + SpinalSim benches |
 | `ext/SpinalHDL/` | Upstream library as git sub-module |
 | `doc/spinalHDL.html` | SpinalSim + SpinalHDL documentation |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Detailed specs live in **AGENTS.md §5**.
 | **Plugin host** | Compose or swap whole subsystems. | `PluginHost`, `FiberPlugin`, `Plugin[T]` |
 | **Pipeline DSL** | Build pipelines without manual `valid/ready` wiring. | `Node`, `StageLink`, `CtrlLink`, `CtrlLaneApi` |
 
+The host now runs inside a `Database` context so plugins can share typed metadata.
+
 Why the DSL helps:
 
 * Insert or remove a register: swap `DirectLink` → `StageLink`.
@@ -59,7 +61,7 @@ t800/
 ├─ build.sbt
 ├─ src/
 │  ├─ main/scala/t800/
-│  │  ├─ Top.scala              # creates PluginHost + selects plugins
+│  │  ├─ Top.scala              # creates Database + PluginHost, selects plugins
 │  │  └─ plugins/               # ⇐ one FiberPlugin per subsystem
 │  │     ├─ FpuPlugin.scala
 │  │     ├─ SchedulerPlugin.scala

--- a/src/main/scala/spinal/lib/misc/database/DataBase.scala
+++ b/src/main/scala/spinal/lib/misc/database/DataBase.scala
@@ -1,0 +1,110 @@
+package spinal.lib.misc.database
+
+import spinal.core._
+import spinal.core.fiber._
+
+import scala.collection.mutable
+
+/** Provide a API to access a HashMap which uses Element[_ <: Any] as keys The Database object
+  * provide a SpinalHDL ScopeProperty[DataBase] allowing to have one globally accessible implicit
+  * database That globally shared database can be used as a way to exchange "global" variable in a
+  * given context (ex : VexiiRiscv core 3)
+  */
+class Database {
+  // User API
+  def update[T](key: Element[T], value: T) = key.set(this, value)
+  def apply[T](key: Element[T]): T = key.getOn(this)
+  def on[T](body: => T) = Database(this).on(body)
+
+  // "private" API
+  val storage = mutable.LinkedHashMap[Element[_ <: Any], Any]()
+  def storageUpdate[T](key: Element[T], value: T) = storage.update(key, value)
+  def storageGet[T](key: Element[T]): T = storage.apply(key).asInstanceOf[T]
+  def storageGetElseUpdate[T](key: Element[T], create: => T): T =
+    storage.getOrElseUpdate(key, create).asInstanceOf[T]
+  def storageExists[T](key: Element[T]) = storage.contains(key)
+}
+
+/** Provide a global implicit database
+  */
+object Database extends ScopeProperty[Database] {
+  def on[T](body: => T) =
+    this(new Database).on(body) // Set the implicit database to be used ojn the given body of code.
+
+  // Here is a few ways you can define new Element instances (which can be used as a key to the data base)
+  def value[T]() = new ElementValue[T]()
+  def blocking[T]() = new ElementBlocking[T]()
+  def landa[T](body: => T) = new ElementLanda(body)
+}
+
+object Element {
+  implicit def toValue[T](p: Element[T]): T = p.get
+
+  class ThingIntPimper(p: Element[Int]) {
+    def bits = BitCount(p.get)
+    def bit = BitCount(p.get)
+  }
+
+  implicit def thingIntPimperFunc(p: Element[Int]): ThingIntPimper = new ThingIntPimper(p)
+}
+
+/** Represent a thing which can be in a data base (this is the key)
+  */
+abstract class Element[T](sp: ScopeProperty[Database] = Database) extends Nameable {
+  // user API
+  def get: T = getOn(sp.get)
+  def apply: T = getOn(sp.get)
+  def set(value: T): Unit = set(sp.get, value)
+  def isEmpty: Boolean = isEmpty(sp.get)
+
+  // private API
+  def isEmpty(db: Database): Boolean
+  def getOn(db: Database): T
+  def set(db: Database, value: T): Unit
+}
+
+/** Simple implementation, which allow to get/set a value Will throw an exception if we try to get
+  * something which isn't set.
+  */
+class ElementValue[T](sp: ScopeProperty[Database] = Database) extends Element[T](sp) {
+  def getOn(db: Database): T = db.storageGet(this)
+  def set(db: Database, value: T) = db.storageUpdate(this, value)
+  override def isEmpty(db: Database): Boolean = ???
+}
+
+/** Same as ElementValue, but based on the SpinalHDL Fiber API. Meaning that when we get something
+  * which isn't set, it will put the current fiber thread in sleep until the thing is set.
+  */
+class ElementBlocking[T](sp: ScopeProperty[Database] = Database) extends Element[T](sp) with Area {
+  val thing = new ElementValue[Handle[T]]()
+  def getHandle(db: Database): Handle[T] =
+    db.storageGetElseUpdate(thing, new Handle[T].setCompositeName(this))
+  def getOn(db: Database): T = getHandle(db).get
+  def set(db: Database, value: T) = {
+    val handle = getHandle(db)
+    if (handle.isLoaded) {
+      assert(handle.get == value, s"DB was set to ${handle.get} before, can't overwrite to $value")
+    }
+    handle.load(value)
+  }
+
+  def soon(): Unit = {
+    getHandle(sp.get).willBeLoadedBy = AsyncThread.current
+    AsyncThread.current.willLoadHandles += getHandle(sp.get)
+  }
+  override def isEmpty(db: Database): Boolean = !getHandle(db).isLoaded
+}
+
+/** The body provide the processing to generate the value
+  */
+class ElementLanda[T](body: => T, sp: ScopeProperty[Database] = Database)
+    extends ElementValue[T](sp) {
+  override def getOn(db: Database): T = {
+    if (!db.storageExists(this)) {
+      db.storageUpdate(this, body)
+    }
+    super.getOn(db)
+  }
+
+  override def set(db: Database, value: T) = ???
+}

--- a/src/main/scala/t800/T800Core.scala
+++ b/src/main/scala/t800/T800Core.scala
@@ -2,9 +2,11 @@ package t800
 
 import spinal.core._
 import t800.plugins._
+import spinal.lib.misc.database._
 
 class T800(plugins: Seq[FiberPlugin]) extends Component {
-  val host = new PluginHost
+  val database = new Database
+  val host = database.on(new PluginHost)
   host.asHostOf(plugins)
 }
 


### PR DESCRIPTION
### What & Why
* vendor `DataBase.scala` so the project builds without an external jar
* create `PluginHost` within `database.on` for clearer scope handling

### Validation
- [x] sbt scalafmtAll
- [x] `sbt test`

------
https://chatgpt.com/codex/tasks/task_e_684c190d1ffc83259a4aacb3b1b7acbc