### PR TITLE
Expose FPU precision and queue depth handles

### DIFF
--- a/src/main/scala/t800/Global.scala
+++ b/src/main/scala/t800/Global.scala
@@ -12,5 +12,7 @@ object Global extends AreaObject {
   val ROM_WORDS = Database.blocking[Int]
   val RAM_WORDS = Database.blocking[Int]
   val LINK_COUNT = Database.blocking[Int]
+  val FPU_PRECISION = Database.blocking[Int]
+  val SCHED_QUEUE_DEPTH = Database.blocking[Int]
   val RESET_PC = Database.blocking[Long]
 }

--- a/src/main/scala/t800/T800Core.scala
+++ b/src/main/scala/t800/T800Core.scala
@@ -15,6 +15,8 @@ object T800 {
     db(Global.ROM_WORDS) = TConsts.RomWords
     db(Global.RAM_WORDS) = TConsts.RamWords
     db(Global.LINK_COUNT) = TConsts.LinkCount
+    db(Global.FPU_PRECISION) = TConsts.FpuPrecision
+    db(Global.SCHED_QUEUE_DEPTH) = TConsts.SchedQueueDepth
     db(Global.RESET_PC) = TConsts.ResetPC
     db
   }

--- a/src/main/scala/t800/TConsts.scala
+++ b/src/main/scala/t800/TConsts.scala
@@ -7,6 +7,8 @@ object TConsts {
   val RamWords = 4096
   val MicroWords = 1024
   val LinkCount = 4
+  val FpuPrecision = WordBits
+  val SchedQueueDepth = LinkCount
   val ResetPC = 0x0000_0000L
 
   // Memory layout

--- a/src/test/scala/t800/GlobalDatabaseSpec.scala
+++ b/src/test/scala/t800/GlobalDatabaseSpec.scala
@@ -15,6 +15,8 @@ class GlobalDatabaseSpec extends AnyFunSuite {
     db(Global.ROM_WORDS) = TConsts.RomWords
     db(Global.RAM_WORDS) = TConsts.RamWords
     db(Global.LINK_COUNT) = TConsts.LinkCount
+    db(Global.FPU_PRECISION) = TConsts.FpuPrecision
+    db(Global.SCHED_QUEUE_DEPTH) = TConsts.SchedQueueDepth
     db(Global.RESET_PC) = TConsts.ResetPC
 
     SimConfig


### PR DESCRIPTION
### What & Why
* Added `FPU_PRECISION` and `SCHED_QUEUE_DEPTH` handles under `Global`.
* `T800.defaultDatabase()` now provides defaults for these settings.
* Updated database unit test to include the new options.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test`
- [ ] `sbt "runMain t800.TopVerilog"`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684c36b066108325ad0b7ac78a7eaaca