### PR TITLE
Split instruction fetch service

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -16,10 +16,10 @@ The pipeline DSL ensures stall/flush control between stages.
 
 ## Plugin responsibilities
 
-- `FetchPlugin` – maintains the PC and fetches bytes from `InstrBusSrv`.
+- `FetchPlugin` – maintains the PC and fetches bytes from `InstrFetchSrv`.
 - `ExecutePlugin` – implements integer ALU operations. More opcodes will be
   added per milestone.
-- `MemoryPlugin` – simple on-chip ROM and RAM. Provides `InstrBusSrv` and
+- `MemoryPlugin` – simple on-chip ROM and RAM. Provides `InstrFetchSrv` and
   `DataBusSrv`.
 - `FpuPlugin` – placeholder FPU interface; future variants may swap a different
   implementation.

--- a/src/main/scala/t800/plugins/FetchPlugin.scala
+++ b/src/main/scala/t800/plugins/FetchPlugin.scala
@@ -8,7 +8,7 @@ import spinal.lib.misc.plugin.{Plugin, PluginHost, FiberPlugin}
 class FetchPlugin extends FiberPlugin {
   val logic = during build new Area {
     implicit val h: PluginHost = host
-    val imem = Plugin[InstrBusSrv]
+    val imem = Plugin[InstrFetchSrv]
     val pipe = Plugin[PipelineSrv]
     val stack = Plugin[StackSrv]
 

--- a/src/main/scala/t800/plugins/MemoryPlugin.scala
+++ b/src/main/scala/t800/plugins/MemoryPlugin.scala
@@ -49,7 +49,7 @@ class MemoryPlugin(romInit: Seq[BigInt] = Seq.fill(TConsts.RomWords)(BigInt(0)))
     dataWrCmdReg.valid := False
     dataWrCmdReg.payload.addr := U(0)
     dataWrCmdReg.payload.data := B(0, Global.WORD_BITS bits)
-    addService(new InstrBusSrv {
+    addService(new InstrFetchSrv {
       override def cmd = instrCmdReg
       override def rsp = instrRspReg
     })

--- a/src/main/scala/t800/plugins/Services.scala
+++ b/src/main/scala/t800/plugins/Services.scala
@@ -67,7 +67,7 @@ trait TimerSrv {
   def disableLo(): Unit
 }
 
-trait InstrBusSrv {
+trait InstrFetchSrv {
   def cmd: Flow[t800.MemReadCmd]
   def rsp: Flow[Bits]
 }


### PR DESCRIPTION
### What & Why
* Renamed the instruction memory API to `InstrFetchSrv` for clarity.
* Updated `FetchPlugin` and `MemoryPlugin` to use the new service.
* Adjusted architecture docs accordingly.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test` *(fails: SpinalHDL async engine is stuck)*
- [ ] `sbt "runMain t800.TopVerilog"` *(failed: NullPointerException)*

------
https://chatgpt.com/codex/tasks/task_e_684c3cd4e9408325a33b54f282d0814e