### PR TITLE
Add PC and memory payloads

### DIFF
--- a/src/main/scala/t800/Global.scala
+++ b/src/main/scala/t800/Global.scala
@@ -2,6 +2,7 @@ package t800
 
 import spinal.core._
 import spinal.lib.misc.database.Database
+import spinal.lib.misc.pipeline._
 
 /** Global configuration elements accessed via [[Database]]. Plugins should use these handles rather
   * than constants in [[TConsts]].
@@ -9,10 +10,17 @@ import spinal.lib.misc.database.Database
 object Global extends AreaObject {
   val WORD_BITS = Database.blocking[Int]
   val ADDR_BITS = Database.blocking[Int]
+  val PC_BITS = Database.blocking[Int]
+  val INSTR_BITS = Database.blocking[Int]
   val ROM_WORDS = Database.blocking[Int]
   val RAM_WORDS = Database.blocking[Int]
   val LINK_COUNT = Database.blocking[Int]
   val FPU_PRECISION = Database.blocking[Int]
   val SCHED_QUEUE_DEPTH = Database.blocking[Int]
   val RESET_PC = Database.blocking[Long]
+
+  def PC: Payload[UInt] = Payload(UInt(PC_BITS bits))
+  def INSTR: Payload[Bits] = Payload(Bits(INSTR_BITS bits))
+  def MEM_ADDR: Payload[UInt] = Payload(UInt(ADDR_BITS bits))
+  def MEM_DATA: Payload[Bits] = Payload(Bits(WORD_BITS bits))
 }

--- a/src/main/scala/t800/T800Core.scala
+++ b/src/main/scala/t800/T800Core.scala
@@ -12,6 +12,8 @@ object T800 {
     val db = new Database
     db(Global.WORD_BITS) = TConsts.WordBits
     db(Global.ADDR_BITS) = TConsts.AddrBits
+    db(Global.PC_BITS) = TConsts.AddrBits
+    db(Global.INSTR_BITS) = 8
     db(Global.ROM_WORDS) = TConsts.RomWords
     db(Global.RAM_WORDS) = TConsts.RamWords
     db(Global.LINK_COUNT) = TConsts.LinkCount

--- a/src/main/scala/t800/plugins/ExecutePlugin.scala
+++ b/src/main/scala/t800/plugins/ExecutePlugin.scala
@@ -49,7 +49,7 @@ class ExecutePlugin extends FiberPlugin {
     val dma = dmaOpt.getOrElse(dummyDma)
     val sched = Plugin[SchedSrv]
 
-    val inst = pipe.execute(pipe.INSTR)
+    val inst = pipe.execute(Global.INSTR)
     val nibble = inst(3 downto 0).asUInt
     val accumulated = stack.O | nibble.resized
     val primary = inst(7 downto 4)

--- a/src/main/scala/t800/plugins/FetchPlugin.scala
+++ b/src/main/scala/t800/plugins/FetchPlugin.scala
@@ -3,6 +3,7 @@ package t800.plugins
 import spinal.core._
 import spinal.lib._
 import spinal.lib.misc.plugin.{Plugin, PluginHost, FiberPlugin}
+import t800.Global
 
 /** Instruction fetch unit using the pipeline framework. */
 class FetchPlugin extends FiberPlugin {
@@ -17,7 +18,8 @@ class FetchPlugin extends FiberPlugin {
     imem.cmd.payload.addr := (addr >> 2).resized
     pipe.fetch.haltWhen(!imem.rsp.valid)
     when(pipe.fetch.down.isFiring) { stack.IPtr := stack.IPtr + 1 }
-    val shift = addr(1 downto 0) * 8
-    pipe.fetch(pipe.INSTR) := (imem.rsp.payload >> shift)(7 downto 0)
+    val shift = addr(1 downto 0) * U(Global.INSTR_BITS)
+    pipe.fetch(Global.PC) := addr
+    pipe.fetch(Global.INSTR) := (imem.rsp.payload >> shift)(Global.INSTR_BITS - 1 downto 0)
   }
 }

--- a/src/main/scala/t800/plugins/StackPlugin.scala
+++ b/src/main/scala/t800/plugins/StackPlugin.scala
@@ -21,7 +21,7 @@ class StackPlugin extends FiberPlugin {
     regC = Reg(UInt(Global.WORD_BITS bits)) init 0
     regO = Reg(UInt(Global.WORD_BITS bits)) init 0
     regWPtr = Reg(UInt(Global.ADDR_BITS bits)) init 0
-    regIPtr = Reg(UInt(Global.ADDR_BITS bits)) init U(Global.RESET_PC)
+    regIPtr = Reg(UInt(Global.PC_BITS bits)) init U(Global.RESET_PC)
     workspace = Mem(UInt(Global.WORD_BITS bits), Global.RAM_WORDS)
 
     addService(new StackSrv {

--- a/src/test/scala/t800/GlobalDatabaseSpec.scala
+++ b/src/test/scala/t800/GlobalDatabaseSpec.scala
@@ -12,6 +12,8 @@ class GlobalDatabaseSpec extends AnyFunSuite {
     val db = new Database
     db(Global.WORD_BITS) = 16
     db(Global.ADDR_BITS) = TConsts.AddrBits
+    db(Global.PC_BITS) = TConsts.AddrBits
+    db(Global.INSTR_BITS) = 8
     db(Global.ROM_WORDS) = TConsts.RomWords
     db(Global.RAM_WORDS) = TConsts.RamWords
     db(Global.LINK_COUNT) = TConsts.LinkCount


### PR DESCRIPTION
### What & Why
* Introduced configurable instruction and PC widths via database.
* Pipeline plugin now exposes global payloads for PC and memory signals.
* Fetch unit sources instruction and PC payloads from `Global`.
* Updated stack pointer width and default database.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test` *(fails: 7 tests)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684c40d1f0808325bcb188c6dbbf8d1f