### PR TITLE
Rename PC configuration to IPTR

### DIFF
--- a/src/main/scala/t800/Global.scala
+++ b/src/main/scala/t800/Global.scala
@@ -12,15 +12,17 @@ object Global extends AreaObject {
   val ADDR_BITS = Database.blocking[Int]
   val PC_BITS = Database.blocking[Int]
   val INSTR_BITS = Database.blocking[Int]
+  val IPTR_BITS = Database.blocking[Int]
+  val OPCODE_BITS = Database.blocking[Int]
   val ROM_WORDS = Database.blocking[Int]
   val RAM_WORDS = Database.blocking[Int]
   val LINK_COUNT = Database.blocking[Int]
   val FPU_PRECISION = Database.blocking[Int]
   val SCHED_QUEUE_DEPTH = Database.blocking[Int]
-  val RESET_PC = Database.blocking[Long]
+  val RESET_IPTR = Database.blocking[Long]
 
-  def PC: Payload[UInt] = Payload(UInt(PC_BITS bits))
-  def INSTR: Payload[Bits] = Payload(Bits(INSTR_BITS bits))
+  def IPTR: Payload[UInt] = Payload(UInt(IPTR_BITS bits))
+  def OPCODE: Payload[Bits] = Payload(Bits(OPCODE_BITS bits))
   def MEM_ADDR: Payload[UInt] = Payload(UInt(ADDR_BITS bits))
   def MEM_DATA: Payload[Bits] = Payload(Bits(WORD_BITS bits))
 }

--- a/src/main/scala/t800/T800Core.scala
+++ b/src/main/scala/t800/T800Core.scala
@@ -14,12 +14,14 @@ object T800 {
     db(Global.ADDR_BITS) = TConsts.AddrBits
     db(Global.PC_BITS) = TConsts.AddrBits
     db(Global.INSTR_BITS) = 8
+    db(Global.IPTR_BITS) = TConsts.AddrBits
+    db(Global.OPCODE_BITS) = 8
     db(Global.ROM_WORDS) = TConsts.RomWords
     db(Global.RAM_WORDS) = TConsts.RamWords
     db(Global.LINK_COUNT) = TConsts.LinkCount
     db(Global.FPU_PRECISION) = TConsts.FpuPrecision
     db(Global.SCHED_QUEUE_DEPTH) = TConsts.SchedQueueDepth
-    db(Global.RESET_PC) = TConsts.ResetPC
+    db(Global.RESET_IPTR) = TConsts.ResetIPtr
     db
   }
 }

--- a/src/main/scala/t800/TConsts.scala
+++ b/src/main/scala/t800/TConsts.scala
@@ -9,7 +9,7 @@ object TConsts {
   val LinkCount = 4
   val FpuPrecision = WordBits
   val SchedQueueDepth = LinkCount
-  val ResetPC = 0x0000_0000L
+  val ResetIPtr = 0x0000_0000L
 
   // Memory layout
   val InternalMemStart = 0x80000000L

--- a/src/main/scala/t800/plugins/ExecutePlugin.scala
+++ b/src/main/scala/t800/plugins/ExecutePlugin.scala
@@ -49,7 +49,7 @@ class ExecutePlugin extends FiberPlugin {
     val dma = dmaOpt.getOrElse(dummyDma)
     val sched = Plugin[SchedSrv]
 
-    val inst = pipe.execute(Global.INSTR)
+    val inst = pipe.execute(Global.OPCODE)
     val nibble = inst(3 downto 0).asUInt
     val accumulated = stack.O | nibble.resized
     val primary = inst(7 downto 4)

--- a/src/main/scala/t800/plugins/FetchPlugin.scala
+++ b/src/main/scala/t800/plugins/FetchPlugin.scala
@@ -18,8 +18,8 @@ class FetchPlugin extends FiberPlugin {
     imem.cmd.payload.addr := (addr >> 2).resized
     pipe.fetch.haltWhen(!imem.rsp.valid)
     when(pipe.fetch.down.isFiring) { stack.IPtr := stack.IPtr + 1 }
-    val shift = addr(1 downto 0) * U(Global.INSTR_BITS)
-    pipe.fetch(Global.PC) := addr
-    pipe.fetch(Global.INSTR) := (imem.rsp.payload >> shift)(Global.INSTR_BITS - 1 downto 0)
+    val shift = addr(1 downto 0) * U(Global.OPCODE_BITS)
+    pipe.fetch(Global.IPTR) := addr
+    pipe.fetch(Global.OPCODE) := (imem.rsp.payload >> shift)(Global.OPCODE_BITS - 1 downto 0)
   }
 }

--- a/src/main/scala/t800/plugins/PipelinePlugin.scala
+++ b/src/main/scala/t800/plugins/PipelinePlugin.scala
@@ -13,8 +13,8 @@ trait PipelineSrv {
   def execute: CtrlLink
   def memory: CtrlLink
   def writeBack: CtrlLink
-  def INSTR: Payload[Bits]
-  def PC: Payload[UInt]
+  def OPCODE: Payload[Bits]
+  def IPTR: Payload[UInt]
   def MEM_ADDR: Payload[UInt]
   def MEM_DATA: Payload[Bits]
 }
@@ -39,8 +39,8 @@ class PipelinePlugin extends FiberPlugin {
     Seq(fetchReg, decodeReg, executeReg, memoryReg, writeBackReg).foreach(_.down.isFiring)
     // Pre-create the global payloads across stages
     Seq(fetchReg, decodeReg, executeReg, memoryReg, writeBackReg).foreach { stage =>
-      stage(Global.INSTR)
-      stage(Global.PC)
+      stage(Global.OPCODE)
+      stage(Global.IPTR)
       stage(Global.MEM_ADDR)
       stage(Global.MEM_DATA)
     }
@@ -51,8 +51,8 @@ class PipelinePlugin extends FiberPlugin {
   def execute: CtrlLink = executeReg
   def memory: CtrlLink = memoryReg
   def writeBack: CtrlLink = writeBackReg
-  def INSTR: Payload[Bits] = Global.INSTR
-  def PC: Payload[UInt] = Global.PC
+  def OPCODE: Payload[Bits] = Global.OPCODE
+  def IPTR: Payload[UInt] = Global.IPTR
   def MEM_ADDR: Payload[UInt] = Global.MEM_ADDR
   def MEM_DATA: Payload[Bits] = Global.MEM_DATA
 
@@ -65,8 +65,8 @@ class PipelinePlugin extends FiberPlugin {
       override def execute = executeReg
       override def memory = memoryReg
       override def writeBack = writeBackReg
-      override def INSTR = Global.INSTR
-      override def PC = Global.PC
+      override def OPCODE = Global.OPCODE
+      override def IPTR = Global.IPTR
       override def MEM_ADDR = Global.MEM_ADDR
       override def MEM_DATA = Global.MEM_DATA
     })

--- a/src/main/scala/t800/plugins/StackPlugin.scala
+++ b/src/main/scala/t800/plugins/StackPlugin.scala
@@ -21,7 +21,7 @@ class StackPlugin extends FiberPlugin {
     regC = Reg(UInt(Global.WORD_BITS bits)) init 0
     regO = Reg(UInt(Global.WORD_BITS bits)) init 0
     regWPtr = Reg(UInt(Global.ADDR_BITS bits)) init 0
-    regIPtr = Reg(UInt(Global.PC_BITS bits)) init U(Global.RESET_PC)
+    regIPtr = Reg(UInt(Global.IPTR_BITS bits)) init U(Global.RESET_IPTR)
     workspace = Mem(UInt(Global.WORD_BITS bits), Global.RAM_WORDS)
 
     addService(new StackSrv {

--- a/src/test/scala/t800/GlobalDatabaseSpec.scala
+++ b/src/test/scala/t800/GlobalDatabaseSpec.scala
@@ -14,12 +14,14 @@ class GlobalDatabaseSpec extends AnyFunSuite {
     db(Global.ADDR_BITS) = TConsts.AddrBits
     db(Global.PC_BITS) = TConsts.AddrBits
     db(Global.INSTR_BITS) = 8
+    db(Global.IPTR_BITS) = TConsts.AddrBits
+    db(Global.OPCODE_BITS) = 8
     db(Global.ROM_WORDS) = TConsts.RomWords
     db(Global.RAM_WORDS) = TConsts.RamWords
     db(Global.LINK_COUNT) = TConsts.LinkCount
     db(Global.FPU_PRECISION) = TConsts.FpuPrecision
     db(Global.SCHED_QUEUE_DEPTH) = TConsts.SchedQueueDepth
-    db(Global.RESET_PC) = TConsts.ResetPC
+    db(Global.RESET_IPTR) = TConsts.ResetIPtr
 
     SimConfig
       .compile {


### PR DESCRIPTION
### What & Why
* Rename reset and instruction fetch fields to use `IPTR`/`OPCODE`
* Updated plugins and tests for new `Global` names

### Validation
- [x] `sbt scalafmtAll`
- [x] `sbt test` *(fails: GlobalDatabaseSpec, FpuPluginSpec, ChannelDmaSpec, TimerEnableSpec)*

------
https://chatgpt.com/codex/tasks/task_e_684c4ac749ec8325818072ba1df1623a