### PR TITLE
Refactor memory and DMA logic with pipeline DSL

### DIFF
--- a/src/main/scala/t800/plugins/MemoryPlugin.scala
+++ b/src/main/scala/t800/plugins/MemoryPlugin.scala
@@ -5,6 +5,7 @@ import spinal.lib._
 import spinal.core.sim._
 import spinal.lib.misc.plugin.{FiberPlugin, Plugin, PluginHost}
 import spinal.core.fiber.{Retainer, Lock}
+import spinal.lib.misc.pipeline._
 import t800.{MemReadCmd, MemWriteCmd, TConsts, Global}
 
 /** Simple on-chip memory for instructions. */
@@ -83,33 +84,101 @@ class MemoryPlugin(romInit: Seq[BigInt] = Seq.fill(TConsts.RomWords)(BigInt(0)))
     busArb.io.exeWr << exeWrCmd
     busArb.io.chanRd << chanRdCmd
     busArb.io.chanWr << chanWrCmd
-    linkRdCmdReg.valid := busArb.io.rdOut.valid
-    linkRdCmdReg.payload := busArb.io.rdOut.payload
-    linkWrCmdReg.valid := busArb.io.wrOut.valid
-    linkWrCmdReg.payload := busArb.io.wrOut.payload
+
+    // Stage the arbiter results before hitting RAM
+    val rdA = CtrlLink()
+    val rdB = CtrlLink()
+    val wrA = CtrlLink()
+    val wrB = CtrlLink()
+    val rdBuf = S2MLink(rdA.down, rdB.up)
+    val wrBuf = S2MLink(wrA.down, wrB.up)
+    rdA.up.driveFrom(busArb.io.rdOut)((n, p) => n(Global.MEM_ADDR) := p.addr)
+    wrA.up.driveFrom(busArb.io.wrOut) { (n, p) =>
+      n(Global.MEM_ADDR) := p.addr
+      n(Global.MEM_DATA) := p.data
+    }
+    val stagedRd = rdB.down.toFlow { n =>
+      val cmd = MemReadCmd()
+      cmd.addr := n(Global.MEM_ADDR)
+      cmd
+    }
+    val stagedWr = wrB.down.toFlow { n =>
+      val cmd = MemWriteCmd()
+      cmd.addr := n(Global.MEM_ADDR)
+      cmd.data := n(Global.MEM_DATA)
+      cmd
+    }
+    linkRdCmdReg << stagedRd
+    linkWrCmdReg << stagedWr
+
+    // Instruction read pipeline
+    val iCmd = CtrlLink()
+    val iDo = CtrlLink()
+    val iStage = StageLink(iCmd.down, iDo.up)
+    iCmd.up.driveFrom(instrCmdReg)((n, p) => n(Global.MEM_ADDR) := p.addr)
     instrRspReg.payload := rom.readSync(
-      instrCmdReg.payload.addr(log2Up(Global.ROM_WORDS) - 1 downto 0)
+      iDo(Global.MEM_ADDR)(log2Up(Global.ROM_WORDS) - 1 downto 0)
     )
-    instrRspReg.valid := instrCmdReg.valid
+    instrRspReg.valid := iDo.isValid
+
+    // Data read pipeline
+    val dCmd = CtrlLink()
+    val dDo = CtrlLink()
+    val dStage = StageLink(dCmd.down, dDo.up)
+    dCmd.up.driveFrom(dataRdCmdReg)((n, p) => n(Global.MEM_ADDR) := p.addr)
     dataRdRspReg.payload := ram.readSync(
-      dataRdCmdReg.payload.addr(log2Up(Global.RAM_WORDS) - 1 downto 0)
+      dDo(Global.MEM_ADDR)(log2Up(Global.RAM_WORDS) - 1 downto 0)
     )
-    dataRdRspReg.valid := dataRdCmdReg.valid
+    dataRdRspReg.valid := dDo.isValid
+
+    // Link read pipeline
+    val lCmd = CtrlLink()
+    val lDo = CtrlLink()
+    val lStage = StageLink(lCmd.down, lDo.up)
+    lCmd.up.driveFrom(linkRdCmdReg)((n, p) => n(Global.MEM_ADDR) := p.addr)
     linkRdRspReg.payload := ram.readSync(
-      linkRdCmdReg.payload.addr(log2Up(Global.RAM_WORDS) - 1 downto 0)
+      lDo(Global.MEM_ADDR)(log2Up(Global.RAM_WORDS) - 1 downto 0)
     )
-    linkRdRspReg.valid := linkRdCmdReg.valid
-    when(dataWrCmdReg.valid) {
+    linkRdRspReg.valid := lDo.isValid
+
+    // Data write pipeline
+    val dwCmd = CtrlLink()
+    val dwDo = CtrlLink()
+    val dwStage = StageLink(dwCmd.down, dwDo.up)
+    dwCmd.up.driveFrom(dataWrCmdReg) { (n, p) =>
+      n(Global.MEM_ADDR) := p.addr
+      n(Global.MEM_DATA) := p.data
+    }
+    when(dwDo.isValid) {
       ram.write(
-        dataWrCmdReg.payload.addr(log2Up(Global.RAM_WORDS) - 1 downto 0),
-        dataWrCmdReg.payload.data
+        dwDo(Global.MEM_ADDR)(log2Up(Global.RAM_WORDS) - 1 downto 0),
+        dwDo(Global.MEM_DATA)
       )
     }
-    when(linkWrCmdReg.valid) {
+
+    // Link write pipeline
+    val lwCmd = CtrlLink()
+    val lwDo = CtrlLink()
+    val lwStage = StageLink(lwCmd.down, lwDo.up)
+    lwCmd.up.driveFrom(linkWrCmdReg) { (n, p) =>
+      n(Global.MEM_ADDR) := p.addr
+      n(Global.MEM_DATA) := p.data
+    }
+    when(lwDo.isValid) {
       ram.write(
-        linkWrCmdReg.payload.addr(log2Up(Global.RAM_WORDS) - 1 downto 0),
-        linkWrCmdReg.payload.data
+        lwDo(Global.MEM_ADDR)(log2Up(Global.RAM_WORDS) - 1 downto 0),
+        lwDo(Global.MEM_DATA)
       )
     }
+
+    Builder(
+      rdBuf,
+      wrBuf,
+      iStage,
+      dStage,
+      lStage,
+      dwStage,
+      lwStage
+    )
   }
 }


### PR DESCRIPTION
### What & Why
* Move memory accesses to `StageLink`/`S2MLink` pipelines.
* Rework channel DMA to use `CtrlLink` with DSL stalls.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test`

Some tests fail due to runtime issues after refactoring.

------
https://chatgpt.com/codex/tasks/task_e_684c4e5a906c8325a5cacb5cb4be3e9a