### PR TITLE
Improve submodule guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ verilator --version
 git clone --recursive https://github.com/agentdavo/t800.git
 cd t800
 
+# Ensure the bundled SpinalHDL submodule is present when
+# using `SPINALHDL_FROM_SOURCE=1`.
+git submodule update --init --recursive
+./scripts/check-submodules.sh
+
 # Default plugin set
 sbt scalafmtAll
 sbt test

--- a/scripts/check-submodules.sh
+++ b/scripts/check-submodules.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ ! -f "ext/SpinalHDL/build.sbt" ]; then
+    echo "Error: submodule 'ext/SpinalHDL' not initialized."
+    echo "Run 'git submodule update --init --recursive' to fetch it." >&2
+    exit 1
+fi
+
+echo "SpinalHDL submodule present."


### PR DESCRIPTION
### What & Why
- highlight submodule initialization in the quick-start
- add helper script to verify the SpinalHDL submodule

### Validation
- `sbt scalafmtCheckAll`
- `sbt test` *(fails: Tests unsuccessful)*

------
https://chatgpt.com/codex/tasks/task_e_684c5553d04883258520d1f080f7cd02