### PR TITLE
Fix Spinal plugin initialization

### DIFF
--- a/src/main/scala/t800/Top.scala
+++ b/src/main/scala/t800/Top.scala
@@ -7,20 +7,21 @@ import t800.plugins._
 /** Variant-aware entry point used by the build scripts. */
 object TopVerilog {
   def main(args: Array[String]): Unit = {
-    val plugins = Seq(
-      new StackPlugin,
-      new PipelinePlugin,
-      new MemoryPlugin,
-      new FetchPlugin,
-      new ChannelPlugin,
-      new ExecutePlugin,
-      new FpuPlugin,
-      new SchedulerPlugin,
-      new TimerPlugin
-    )
-
-    val host = new PluginHost
-    val db = T800.defaultDatabase()
-    SpinalVerilog(new T800(host, plugins, db))
+    SpinalVerilog {
+      val host = new PluginHost
+      val db = T800.defaultDatabase()
+      val plugins = Seq(
+        new StackPlugin,
+        new PipelinePlugin,
+        new MemoryPlugin,
+        new FetchPlugin,
+        new ChannelPlugin,
+        new ExecutePlugin,
+        new FpuPlugin,
+        new SchedulerPlugin,
+        new TimerPlugin
+      )
+      new T800(host, plugins, db)
+    }
   }
 }

--- a/src/main/scala/t800/plugins/StackPlugin.scala
+++ b/src/main/scala/t800/plugins/StackPlugin.scala
@@ -42,4 +42,8 @@ class StackPlugin extends FiberPlugin {
     })
     retain()
   }
+
+  during build new Area {
+    retain.await()
+  }
 }


### PR DESCRIPTION
### What & Why
* Added missing build phase to `StackPlugin` so its setup retainer is released correctly.
* Moved plugin and host creation inside `SpinalVerilog` in `TopVerilog` to avoid null context errors.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test` *(fails: SpinalHDL async engine is stuck)*
- [ ] `sbt "runMain t800.TopVerilog"` *(fails: Nonzero exit code)*

------
https://chatgpt.com/codex/tasks/task_e_684c54ca5f2c8325b7561165be057956