### PR TITLE
Refactor opcode tests to share dummy plugins

### DIFF
--- a/src/test/scala/t800/ChannelDmaSpec.scala
+++ b/src/test/scala/t800/ChannelDmaSpec.scala
@@ -5,42 +5,8 @@ import spinal.core.sim._
 import spinal.lib._
 import org.scalatest.funsuite.AnyFunSuite
 import t800.plugins._
-import spinal.lib.misc.plugin.{PluginHost, FiberPlugin}
-
-class DummyTimerPlugin extends FiberPlugin {
-  private var hiReg, loReg: UInt = null
-  during setup new Area {
-    hiReg = Reg(UInt(TConsts.WordBits bits)) init 0
-    loReg = Reg(UInt(TConsts.WordBits bits)) init 0
-    addService(new TimerSrv {
-      override def hi: UInt = hiReg
-      override def lo: UInt = loReg
-      override def set(value: UInt): Unit = {
-        hiReg := value
-        loReg := value
-      }
-      override def enableHi(): Unit = {}
-      override def enableLo(): Unit = {}
-      override def disableHi(): Unit = hiReg := hiReg
-      override def disableLo(): Unit = loReg := loReg
-    })
-  }
-}
-
-class DummyFpuPlugin extends FiberPlugin {
-  private var pipeReg: Flow[FpCmd] = null
-  private var rspReg: Flow[UInt] = null
-  during setup new Area {
-    pipeReg = Flow(new FpCmd())
-    pipeReg.setIdle()
-    rspReg = Flow(UInt(TConsts.WordBits bits))
-    rspReg.setIdle()
-    addService(new FpuSrv {
-      override def pipe: Flow[FpCmd] = pipeReg
-      override def rsp: Flow[UInt] = rspReg
-    })
-  }
-}
+import spinal.lib.misc.plugin.PluginHost
+import t800.{DummyTimerPlugin, DummyFpuPlugin}
 
 class ChannelDmaSpec extends AnyFunSuite {
   test("DMA opcode transfers bytes") {
@@ -56,11 +22,11 @@ class ChannelDmaSpec extends AnyFunSuite {
             new PipelinePlugin,
             new MemoryPlugin(base),
             new FetchPlugin,
-            new ExecutePlugin,
             new ChannelPlugin,
-            new SchedulerPlugin,
             new DummyTimerPlugin,
-            new DummyFpuPlugin
+            new DummyFpuPlugin,
+            new ExecutePlugin,
+            new SchedulerPlugin
           )
           new T800(host, p)
         }

--- a/src/test/scala/t800/OprLdlSpec.scala
+++ b/src/test/scala/t800/OprLdlSpec.scala
@@ -1,0 +1,45 @@
+package t800
+
+import spinal.core._
+import spinal.core.sim._
+import org.scalatest.funsuite.AnyFunSuite
+import t800.plugins._
+import spinal.lib._
+import spinal.lib.misc.plugin.PluginHost
+
+import t800.{DummyTimerPlugin, DummyFpuPlugin}
+
+class OprLdlSpec extends AnyFunSuite {
+  test("LDL loads from workspace") {
+    val romInit = Seq.fill(16)(BigInt(0))
+    val word0 = BigInt(0x42224323L)
+    val word1 = BigInt(0x70d04121L)
+    val rom = romInit.updated(0, word0).updated(1, word1)
+
+    SimConfig
+      .compile {
+        PluginHost.on {
+          val host = new PluginHost
+          val p = Seq(
+            new StackPlugin,
+            new PipelinePlugin,
+            new MemoryPlugin(rom),
+            new FetchPlugin,
+            new DummyTimerPlugin,
+            new DummyFpuPlugin,
+            new ExecutePlugin,
+            new SchedulerPlugin
+          )
+          new T800(host, p)
+        }
+      }
+      .doSim { dut =>
+        dut.clockDomain.forkStimulus(10)
+        dut.clockDomain.waitSampling(50)
+        val stack = dut.host[StackSrv]
+        assert(stack.A.toBigInt == 0x11)
+        assert(stack.B.toBigInt == 0x22)
+        assert(stack.C.toBigInt == 0x33)
+      }
+  }
+}

--- a/src/test/scala/t800/OprStlSpec.scala
+++ b/src/test/scala/t800/OprStlSpec.scala
@@ -1,0 +1,43 @@
+package t800
+
+import spinal.core._
+import spinal.core.sim._
+import org.scalatest.funsuite.AnyFunSuite
+import t800.plugins._
+import spinal.lib._
+import spinal.lib.misc.plugin.PluginHost
+import t800.{DummyTimerPlugin, DummyFpuPlugin}
+
+class OprStlSpec extends AnyFunSuite {
+  test("STL stores A and updates stack") {
+    val romInit = Seq.fill(16)(BigInt(0))
+    val word0 = BigInt(0x42224323L)
+    val word1 = BigInt(0x00d04121L)
+    val rom = romInit.updated(0, word0).updated(1, word1)
+
+    SimConfig
+      .compile {
+        PluginHost.on {
+          val host = new PluginHost
+          val p = Seq(
+            new StackPlugin,
+            new PipelinePlugin,
+            new MemoryPlugin(rom),
+            new FetchPlugin,
+            new DummyTimerPlugin,
+            new DummyFpuPlugin,
+            new ExecutePlugin,
+            new SchedulerPlugin
+          )
+          new T800(host, p)
+        }
+      }
+      .doSim { dut =>
+        dut.clockDomain.forkStimulus(10)
+        dut.clockDomain.waitSampling(40)
+        val stack = dut.host[StackSrv]
+        assert(stack.A.toBigInt == 0x22)
+        assert(stack.B.toBigInt == 0x33)
+      }
+  }
+}

--- a/src/test/scala/t800/TestPlugins.scala
+++ b/src/test/scala/t800/TestPlugins.scala
@@ -1,0 +1,49 @@
+package t800
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.misc.plugin.FiberPlugin
+import t800.plugins._
+
+/** Minimal timer plugin exposing [[TimerSrv]] without any logic. */
+class DummyTimerPlugin extends FiberPlugin {
+  private var hiReg, loReg: UInt = null
+  during setup new Area {
+    hiReg = Reg(UInt(TConsts.WordBits bits)) init 0
+    loReg = Reg(UInt(TConsts.WordBits bits)) init 0
+    addService(new TimerSrv {
+      override def hi: UInt = hiReg
+      override def lo: UInt = loReg
+      override def set(value: UInt): Unit = {
+        hiReg := value
+        loReg := value
+      }
+      override def enableHi(): Unit = {}
+      override def enableLo(): Unit = {}
+      override def disableHi(): Unit = hiReg := hiReg
+      override def disableLo(): Unit = loReg := loReg
+    })
+  }
+
+  // Provide an empty build phase so awaitBuild() doesn't block
+  during build new Area {}
+}
+
+/** Minimal FPU plugin exposing [[FpuSrv]] without arithmetic. */
+class DummyFpuPlugin extends FiberPlugin {
+  private var pipeReg: Flow[FpCmd] = null
+  private var rspReg: Flow[UInt] = null
+  during setup new Area {
+    pipeReg = Flow(new FpCmd())
+    pipeReg.setIdle()
+    rspReg = Flow(UInt(TConsts.WordBits bits))
+    rspReg.setIdle()
+    addService(new FpuSrv {
+      override def pipe: Flow[FpCmd] = pipeReg
+      override def rsp: Flow[UInt] = rspReg
+    })
+  }
+
+  // Empty build stage required for the fiber engine
+  during build new Area {}
+}


### PR DESCRIPTION
### What & Why
* Replaced ad-hoc dummy timer/FPU implementations with reusable `TestPlugins` helpers
* Updated `OprLdlSpec`, `OprStlSpec`, and `ChannelDmaSpec` to use the shared stubs and adjusted plugin order

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test`

`OprLdlSpec` and `OprStlSpec` still fail due to a SpinalHDL async engine issue during elaboration.

------
https://chatgpt.com/codex/tasks/task_e_684c611a0ad08325b93d5ad022ba5c97