### PR TITLE
Fix FPU plugin default handshake

### DIFF
--- a/src/main/scala/t800/plugins/FpuPlugin.scala
+++ b/src/main/scala/t800/plugins/FpuPlugin.scala
@@ -33,7 +33,9 @@ class FpuPlugin extends FiberPlugin {
 
   during setup new Area {
     pipeReg = Flow(new FpCmd)
+    pipeReg.setIdle()
     rspReg = Flow(UInt(Global.WORD_BITS bits))
+    rspReg.setIdle()
     addService(new FpuSrv {
       override def pipe = pipeReg
       override def rsp = rspReg


### PR DESCRIPTION
### What & Why
* Ensure FPU command/response flows start idle so that users don’t have to drive them.
* Explicitly wait for setup retainer during build.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test` *(fails: 7 tests, including FpuPluginSpec)*

------
https://chatgpt.com/codex/tasks/task_e_684c691384608325b361b6b46093691b