### PR TITLE
Fix timer gating

### DIFF
--- a/src/main/scala/t800/plugins/TimerPlugin.scala
+++ b/src/main/scala/t800/plugins/TimerPlugin.scala
@@ -52,17 +52,19 @@ class TimerPlugin extends FiberPlugin {
       hiTimer := loadVal
       loTimer := loadVal
       loCnt := 0
-    } otherwise {
-      when(hiEn) {
-        hiTimer := hiTimer + 1
-      }
-      when(loEn) {
-        loCnt := loCnt + 1
-        when(loCnt === 0) {
-          loTimer := loTimer + 1
-        }
+    }
+
+    when(!loadReq && hiEn) {
+      hiTimer := hiTimer + 1
+    }
+
+    when(!loadReq && loEn) {
+      loCnt := loCnt + 1
+      when(loCnt === 0) {
+        loTimer := loTimer + 1
       }
     }
+
     when(loadReq) { loadReq := False }
   }
 }


### PR DESCRIPTION
### What & Why
* Guard timer counter increments behind enable flags.
* Verified probe plugin uses `Global.WORD_BITS` width.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test` *(fails: TimerEnableSpec/GlobalDatabaseSpec could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_684c70443ba48325aaf082d25704d132