### PR TITLE
Fix DMA busy flag on completion

### DIFF
--- a/src/main/scala/t800/plugins/ChannelPlugin.scala
+++ b/src/main/scala/t800/plugins/ChannelPlugin.scala
@@ -107,10 +107,12 @@ class ChannelPlugin extends FiberPlugin {
     memTx(linkIdx).payload := byteReg.resized
     dmaDo.haltWhen(haveByte && !memTx(linkIdx).ready)
     when(dmaDo.isValid && haveByte && memTx(linkIdx).ready) {
-      haveByte := False
       when(remaining === 0) {
         busyVec(linkIdx) := False
+        haveByte := False
         dmaDo.throwIt(usingReady = true)
+      } otherwise {
+        haveByte := False
       }
     }
 


### PR DESCRIPTION
### What & Why
* ensure Channel DMA clears `busyVec` and `haveByte` when the last byte is transmitted.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test`
- [ ] `sbt "runMain t800.TopVerilog"`

`ChannelDmaSpec` still fails due to a stuck simulation engine.


------
https://chatgpt.com/codex/tasks/task_e_684c7037d6d08325ae2c76acfbb4988e