### PR TITLE
[M-4] scheduler and memory extensions

### DIFF
--- a/src/main/scala/t800/plugins/SchedulerPlugin.scala
+++ b/src/main/scala/t800/plugins/SchedulerPlugin.scala
@@ -3,6 +3,7 @@ package t800.plugins
 import spinal.core._
 import spinal.lib._
 import spinal.lib.misc.plugin.FiberPlugin
+import spinal.lib.misc.pipeline._
 import spinal.core.fiber.Retainer
 import t800.Global
 
@@ -11,11 +12,9 @@ class SchedulerPlugin extends FiberPlugin {
   private var cmdReg: Flow[SchedCmd] = null
   private var nextReg: UInt = null
 
-  // simple ring buffers
-  private var hiQ: Vec[UInt] = null
-  private var hiHead, hiTail: UInt = null
-  private var loQ: Vec[UInt] = null
-  private var loHead, loTail: UInt = null
+  // simple stream FIFOs for high/low priority queues
+  private var hiFifo: StreamFifo[UInt] = null
+  private var loFifo: StreamFifo[UInt] = null
 
   private val retain = Retainer()
 
@@ -23,12 +22,10 @@ class SchedulerPlugin extends FiberPlugin {
     println(s"[${SchedulerPlugin.this.getDisplayName()}] setup start")
     cmdReg = Flow(SchedCmd())
 
-    hiQ = Vec.fill(Global.LINK_COUNT)(Reg(UInt(Global.ADDR_BITS bits)) init 0)
-    hiHead = Reg(UInt(log2Up(Global.LINK_COUNT) bits)) init 0
-    hiTail = Reg(UInt(log2Up(Global.LINK_COUNT) bits)) init 0
-    loQ = Vec.fill(Global.LINK_COUNT)(Reg(UInt(Global.ADDR_BITS bits)) init 0)
-    loHead = Reg(UInt(log2Up(Global.LINK_COUNT) bits)) init 0
-    loTail = Reg(UInt(log2Up(Global.LINK_COUNT) bits)) init 0
+    hiFifo = StreamFifo(UInt(Global.ADDR_BITS bits), Global.SCHED_QUEUE_DEPTH)
+    loFifo = StreamFifo(UInt(Global.ADDR_BITS bits), Global.SCHED_QUEUE_DEPTH)
+    hiFifo.io.push.setIdle()
+    loFifo.io.push.setIdle()
 
     nextReg = Reg(UInt(Global.ADDR_BITS bits)) init 0
 
@@ -43,22 +40,35 @@ class SchedulerPlugin extends FiberPlugin {
   during build new Area {
     println(s"[${SchedulerPlugin.this.getDisplayName()}] build start")
     retain.await()
-    when(cmdReg.valid) {
-      when(cmdReg.payload.high) {
-        hiQ(hiTail) := cmdReg.payload.ptr
-        hiTail := hiTail + 1
-      } otherwise {
-        loQ(loTail) := cmdReg.payload.ptr
-        loTail := loTail + 1
-      }
+    val CMD_PTR = Payload(UInt(Global.ADDR_BITS bits))
+    val CMD_HI = Payload(Bool())
+    val in = CtrlLink()
+    val toHi = CtrlLink()
+    val toLo = CtrlLink()
+    ForkLink(in.down, Seq(toHi.up, toLo.up))
+    in.up.driveFrom(cmdReg) { (n, p) =>
+      n(CMD_PTR) := p.ptr
+      n(CMD_HI) := p.high
     }
 
-    when(hiHead =/= hiTail) {
-      nextReg := hiQ(hiHead)
-      hiHead := hiHead + 1
-    } elsewhen (loHead =/= loTail) {
-      nextReg := loQ(loHead)
-      loHead := loHead + 1
+    hiFifo.io.push.valid := toHi.isValid && toHi(CMD_HI)
+    hiFifo.io.push.payload := toHi(CMD_PTR)
+    toHi.haltWhen(hiFifo.io.push.valid && !hiFifo.io.push.ready)
+
+    loFifo.io.push.valid := toLo.isValid && !toLo(CMD_HI)
+    loFifo.io.push.payload := toLo(CMD_PTR)
+    toLo.haltWhen(loFifo.io.push.valid && !loFifo.io.push.ready)
+
+    val hiPop = hiFifo.io.pop
+    val loPop = loFifo.io.pop
+    hiPop.ready := False
+    loPop.ready := False
+    when(hiPop.valid) {
+      nextReg := hiPop.payload
+      hiPop.ready := True
+    } elsewhen (loPop.valid) {
+      nextReg := loPop.payload
+      loPop.ready := True
     }
     println(s"[${SchedulerPlugin.this.getDisplayName()}] build end")
   }


### PR DESCRIPTION
### What & Why
* Implement skid-buffered RAM operations in `MemoryPlugin`.
* Rework `SchedulerPlugin` with high/low FIFOs using `ForkLink`.
* Added `PrefixSpec` verifying prefix literal creation.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test`



------
https://chatgpt.com/codex/tasks/task_e_684c7b75ef7c83258047dc67c86f102a