### PR TITLE
Add SpinalHDL design check notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,3 +258,18 @@ details.
   assigns a value, or add a `default` case in `switch`/`mux` constructs.
 * **NullPointerException** – referencing hardware before `val` initialization
   in Scala. Declare signals before using them.
+
+## 14 Design checks
+
+The SpinalHDL compiler rejects many unsafe constructs. Watch out for:
+
+* Assignment overlapping
+* Clock domain crossing mistakes
+* Hierarchy violations
+* Combinatorial loops
+* Latches
+* Undriven signals
+* Width mismatches
+* Unreachable switch statements
+
+Each error includes a stack trace to locate the issue.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,21 @@ in that component or to outputs of children. Breaking these rules triggers a
 `Hierarchy Violation` error during elaboration. Expose required signals via
 services or bundles instead of cross-plugin references.
 
+## SpinalHDL design checks
+
+The compiler catches a wide range of design mistakes:
+
+* Assignment overlapping
+* Clock domain crossing mistakes
+* Hierarchy violations
+* Combinatorial loops
+* Latches
+* Undriven signals
+* Width mismatches
+* Unreachable switch statements
+
+Each report includes a stack trace to pinpoint the offending code.
+
 ---
 
 ## Simulation with SpinalSim


### PR DESCRIPTION
### What & Why
* Document common SpinalHDL design errors in both README and AGENTS

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test`
- [ ] `sbt "runMain t800.TopVerilog"`

------
https://chatgpt.com/codex/tasks/task_e_684c97470de88325bb4936a6ec895737