### PR TITLE
Wrap T800 creation with PluginHost

### DIFF
--- a/src/main/scala/t800/T800Core.scala
+++ b/src/main/scala/t800/T800Core.scala
@@ -54,6 +54,21 @@ class T800Core
 
 object T800CoreVerilog {
   def main(args: Array[String]): Unit = {
-    SpinalVerilog(new T800Core)
+    SpinalVerilog {
+      val host = new PluginHost
+      val plugins = Seq(
+        new StackPlugin,
+        new PipelinePlugin,
+        new MemoryPlugin,
+        new FetchPlugin,
+        new ExecutePlugin,
+        new FpuPlugin,
+        new SchedulerPlugin,
+        new TimerPlugin
+      )
+      PluginHost(host).on {
+        new T800(host, plugins)
+      }
+    }
   }
 }

--- a/src/main/scala/t800/Top.scala
+++ b/src/main/scala/t800/Top.scala
@@ -21,7 +21,9 @@ object TopVerilog {
         new SchedulerPlugin,
         new TimerPlugin
       )
-      new T800(host, plugins, db)
+      PluginHost(host).on {
+        new T800(host, plugins, db)
+      }
     }
   }
 }


### PR DESCRIPTION
### What & Why
* Ensure `T800` instances are built with an active `PluginHost` scope.
* Updated build entry points to apply `PluginHost(host).on` around core creation.

### Validation
- [x] `sbt scalafmtAll`
- [x] `sbt test` *(fails: SpinalHDL async engine stuck)*

------
https://chatgpt.com/codex/tasks/task_e_684c941cdcac8325903b002ccaec805a