### PR TITLE
Refactor ChannelPlugin DMA state machine

### DIFF
--- a/src/main/scala/t800/plugins/ChannelPlugin.scala
+++ b/src/main/scala/t800/plugins/ChannelPlugin.scala
@@ -8,13 +8,17 @@ import spinal.lib.misc.pipeline._
 import t800.{MemReadCmd, MemWriteCmd, TConsts, Global}
 import t800.plugins.{LinkBusSrv, LinkBusArbiterSrv}
 
+object DmaState extends SpinalEnum {
+  val Idle, Read, Push, Complete = newElement()
+}
+
 /** Provides transputer link interfaces with simple FIFO synchronizers. */
 class ChannelPlugin extends FiberPlugin {
   private var pins: ChannelPins = null
   private var rxVec: Vec[Stream[Bits]] = null
   private var txVec: Vec[Stream[Bits]] = null
   private var cmdStream: Stream[ChannelTxCmd] = null
-  private var busyVec: Vec[Bool] = null
+  private var stateVec: Vec[DmaState.C] = null
   private var memTx: Vec[Stream[Bits]] = null
 
   private val retain = Retainer()
@@ -28,7 +32,7 @@ class ChannelPlugin extends FiberPlugin {
     txVec.foreach(_.setIdle())
     rxVec.foreach(_.ready := False)
     cmdStream = Stream(ChannelTxCmd()).setIdle()
-    busyVec = Vec.fill(Global.LINK_COUNT)(Reg(Bool()) init False)
+    stateVec = Vec.fill(Global.LINK_COUNT)(Reg(DmaState()) init DmaState.Idle)
     addService(new ChannelSrv {
       override def txReady(link: UInt): Bool = txVec(link).ready
       override def push(link: UInt, data: Bits): Bool = {
@@ -79,44 +83,58 @@ class ChannelPlugin extends FiberPlugin {
       n(CMD_LEN) := p.length
       n(CMD_LINK) := p.link
     }
-    dmaCmd.haltWhen(busyVec.reduce(_ || _))
+    dmaCmd.haltWhen(stateVec.map(_ =/= DmaState.Idle).reduce(_ || _))
 
     val ptr = Reg(UInt(Global.ADDR_BITS bits)) init 0
     val remaining = Reg(UInt(Global.ADDR_BITS bits)) init 0
     val linkIdx = Reg(UInt(log2Up(Global.LINK_COUNT) bits)) init 0
-    val haveByte = Reg(Bool()) init False
     val byteReg = Reg(Bits(8 bits)) init 0
 
     when(dmaCmd.down.isFiring) {
       ptr := dmaCmd(CMD_ADDR)
       remaining := dmaCmd(CMD_LEN)
       linkIdx := dmaCmd(CMD_LINK)
-      busyVec.foreach(_ := False)
-      busyVec(dmaCmd(CMD_LINK)) := True
+      stateVec.foreach(_ := DmaState.Idle)
+      stateVec(dmaCmd(CMD_LINK)) := DmaState.Read
     }
 
-    arb.chanRd.valid := dmaDo.isValid && !haveByte
-    arb.chanRd.payload.addr := ptr
-    dmaDo.haltWhen(!haveByte && !mem.rdRsp.valid)
-    when(dmaDo.isValid && !haveByte && mem.rdRsp.valid) {
-      val shift = ptr(1 downto 0) * 8
-      byteReg := (mem.rdRsp.payload >> shift)(7 downto 0)
-      haveByte := True
-      ptr := ptr + 1
-      remaining := remaining - 1
-    }
+    val state = stateVec(linkIdx)
 
-    memTx(linkIdx).valid := dmaDo.isValid && haveByte
-    memTx(linkIdx).payload := byteReg.resized
-    dmaDo.haltWhen(haveByte && !memTx(linkIdx).ready)
-    when(dmaDo.isValid && haveByte && memTx(linkIdx).ready) {
-      when(remaining === 0) {
-        busyVec(linkIdx) := False
-        haveByte := False
-        dmaDo.throwIt(usingReady = true)
-      } otherwise {
-        haveByte := False
+    arb.chanRd.valid := False
+    memTx(linkIdx).valid := False
+
+    switch(state) {
+      is(DmaState.Read) {
+        arb.chanRd.valid := dmaDo.isValid
+        arb.chanRd.payload.addr := ptr
+        dmaDo.haltWhen(!mem.rdRsp.valid)
+        when(dmaDo.isValid && mem.rdRsp.valid) {
+          val shift = ptr(1 downto 0) * 8
+          byteReg := (mem.rdRsp.payload >> shift)(7 downto 0)
+          ptr := ptr + 1
+          remaining := remaining - 1
+          stateVec(linkIdx) := DmaState.Push
+        }
       }
+      is(DmaState.Push) {
+        memTx(linkIdx).valid := dmaDo.isValid
+        memTx(linkIdx).payload := byteReg.resized
+        dmaDo.haltWhen(!memTx(linkIdx).ready)
+        when(dmaDo.isValid && memTx(linkIdx).ready) {
+          when(remaining === 0) {
+            stateVec(linkIdx) := DmaState.Complete
+          } otherwise {
+            stateVec(linkIdx) := DmaState.Read
+          }
+        }
+      }
+      is(DmaState.Complete) {
+        when(dmaDo.isValid) {
+          stateVec(linkIdx) := DmaState.Idle
+          dmaDo.throwIt(usingReady = true)
+        }
+      }
+      default {}
     }
 
     Builder(dmaStage)


### PR DESCRIPTION
### What & Why
* Introduce `DmaState` enum and store per-link DMA state.
* Replace `busyVec` and `haveByte` with the new enum registers.
* Rewrite DMA control using a `switch` over `DmaState` to manage read/push/complete transitions.
* Update halt conditions to check for non-idle states.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test`
- [ ] `sbt "runMain t800.TopVerilog"`

`ChannelDmaSpec` fails during elaboration after the refactor, causing the test suite and Verilog generation to abort.


------
https://chatgpt.com/codex/tasks/task_e_684c97aca4888325894ef0d9b8b5be38