### PR TITLE
Wrap T800 creation with PluginHost

### DIFF
--- a/src/main/scala/t800/T800Core.scala
+++ b/src/main/scala/t800/T800Core.scala
@@ -54,6 +54,21 @@ class T800Core
 
 object T800CoreVerilog {
   def main(args: Array[String]): Unit = {
-    SpinalVerilog(new T800Core)
+    SpinalVerilog {
+      val host = new PluginHost
+      val plugins = Seq(
+        new StackPlugin,
+        new PipelinePlugin,
+        new MemoryPlugin,
+        new FetchPlugin,
+        new ExecutePlugin,
+        new FpuPlugin,
+        new SchedulerPlugin,
+        new TimerPlugin
+      )
+      PluginHost(host).on {
+        new T800(host, plugins)
+      }
+    }
   }
 }

--- a/src/main/scala/t800/Top.scala
+++ b/src/main/scala/t800/Top.scala
@@ -21,7 +21,9 @@ object TopVerilog {
         new SchedulerPlugin,
         new TimerPlugin
       )
-      new T800(host, plugins, db)
+      PluginHost(host).on {
+        new T800(host, plugins, db)
+      }
     }
   }
 }

--- a/src/test/scala/t800/ChannelDmaSpec.scala
+++ b/src/test/scala/t800/ChannelDmaSpec.scala
@@ -15,19 +15,19 @@ class ChannelDmaSpec extends AnyFunSuite {
 
     SimConfig
       .compile {
-        PluginHost.on {
-          val host = new PluginHost
-          val p = Seq(
-            new StackPlugin,
-            new PipelinePlugin,
-            new MemoryPlugin(base),
-            new FetchPlugin,
-            new ChannelPlugin,
-            new DummyTimerPlugin,
-            new DummyFpuPlugin,
-            new ExecutePlugin,
-            new SchedulerPlugin
-          )
+        val host = new PluginHost
+        val p = Seq(
+          new StackPlugin,
+          new PipelinePlugin,
+          new MemoryPlugin(base),
+          new FetchPlugin,
+          new ChannelPlugin,
+          new DummyTimerPlugin,
+          new DummyFpuPlugin,
+          new ExecutePlugin,
+          new SchedulerPlugin
+        )
+        PluginHost(host).on {
           new T800(host, p)
         }
       }

--- a/src/test/scala/t800/GlobalDatabaseSpec.scala
+++ b/src/test/scala/t800/GlobalDatabaseSpec.scala
@@ -25,9 +25,9 @@ class GlobalDatabaseSpec extends AnyFunSuite {
 
     SimConfig
       .compile {
-        PluginHost.on {
-          val host = new PluginHost
-          val plugins = Seq(new TimerPlugin, new TimerProbePlugin)
+        val host = new PluginHost
+        val plugins = Seq(new TimerPlugin, new TimerProbePlugin)
+        PluginHost(host).on {
           new T800(host, plugins, db)
         }
       }

--- a/src/test/scala/t800/HelloWorldSim.scala
+++ b/src/test/scala/t800/HelloWorldSim.scala
@@ -14,18 +14,18 @@ object HelloWorldSim {
     ).map(BigInt(_))
     SimConfig.withWave
       .compile {
-        PluginHost.on {
-          val host = new PluginHost
-          val p = Seq(
-            new StackPlugin,
-            new PipelinePlugin,
-            new MemoryPlugin(romInit),
-            new FetchPlugin,
-            new ExecutePlugin,
-            new ChannelPlugin,
-            new SchedulerPlugin,
-            new TimerPlugin
-          )
+        val host = new PluginHost
+        val p = Seq(
+          new StackPlugin,
+          new PipelinePlugin,
+          new MemoryPlugin(romInit),
+          new FetchPlugin,
+          new ExecutePlugin,
+          new ChannelPlugin,
+          new SchedulerPlugin,
+          new TimerPlugin
+        )
+        PluginHost(host).on {
           new T800(host, p)
         }
       }

--- a/src/test/scala/t800/HelloWorldSpec.scala
+++ b/src/test/scala/t800/HelloWorldSpec.scala
@@ -10,18 +10,18 @@ class HelloWorldSpec extends AnyFunSuite {
   ignore("ROM program prints hello world") {
     SimConfig
       .compile {
-        PluginHost.on {
-          val host = new PluginHost
-          val plugins = Seq(
-            new StackPlugin,
-            new PipelinePlugin,
-            new MemoryPlugin,
-            new FetchPlugin,
-            new ExecutePlugin,
-            new ChannelPlugin,
-            new SchedulerPlugin,
-            new TimerPlugin
-          )
+        val host = new PluginHost
+        val plugins = Seq(
+          new StackPlugin,
+          new PipelinePlugin,
+          new MemoryPlugin,
+          new FetchPlugin,
+          new ExecutePlugin,
+          new ChannelPlugin,
+          new SchedulerPlugin,
+          new TimerPlugin
+        )
+        PluginHost(host).on {
           new T800(host, plugins)
         }
       }

--- a/src/test/scala/t800/OprLdlSpec.scala
+++ b/src/test/scala/t800/OprLdlSpec.scala
@@ -18,18 +18,18 @@ class OprLdlSpec extends AnyFunSuite {
 
     SimConfig
       .compile {
-        PluginHost.on {
-          val host = new PluginHost
-          val p = Seq(
-            new StackPlugin,
-            new PipelinePlugin,
-            new MemoryPlugin(rom),
-            new FetchPlugin,
-            new DummyTimerPlugin,
-            new DummyFpuPlugin,
-            new ExecutePlugin,
-            new SchedulerPlugin
-          )
+        val host = new PluginHost
+        val p = Seq(
+          new StackPlugin,
+          new PipelinePlugin,
+          new MemoryPlugin(rom),
+          new FetchPlugin,
+          new DummyTimerPlugin,
+          new DummyFpuPlugin,
+          new ExecutePlugin,
+          new SchedulerPlugin
+        )
+        PluginHost(host).on {
           new T800(host, p)
         }
       }

--- a/src/test/scala/t800/OprStlSpec.scala
+++ b/src/test/scala/t800/OprStlSpec.scala
@@ -17,18 +17,18 @@ class OprStlSpec extends AnyFunSuite {
 
     SimConfig
       .compile {
-        PluginHost.on {
-          val host = new PluginHost
-          val p = Seq(
-            new StackPlugin,
-            new PipelinePlugin,
-            new MemoryPlugin(rom),
-            new FetchPlugin,
-            new DummyTimerPlugin,
-            new DummyFpuPlugin,
-            new ExecutePlugin,
-            new SchedulerPlugin
-          )
+        val host = new PluginHost
+        val p = Seq(
+          new StackPlugin,
+          new PipelinePlugin,
+          new MemoryPlugin(rom),
+          new FetchPlugin,
+          new DummyTimerPlugin,
+          new DummyFpuPlugin,
+          new ExecutePlugin,
+          new SchedulerPlugin
+        )
+        PluginHost(host).on {
           new T800(host, p)
         }
       }

--- a/src/test/scala/t800/PrefixSpec.scala
+++ b/src/test/scala/t800/PrefixSpec.scala
@@ -15,18 +15,18 @@ class PrefixSpec extends AnyFunSuite {
 
     SimConfig
       .compile {
-        PluginHost.on {
-          val host = new PluginHost
-          val p = Seq(
-            new StackPlugin,
-            new PipelinePlugin,
-            new MemoryPlugin(rom),
-            new FetchPlugin,
-            new DummyTimerPlugin,
-            new DummyFpuPlugin,
-            new ExecutePlugin,
-            new SchedulerPlugin
-          )
+        val host = new PluginHost
+        val p = Seq(
+          new StackPlugin,
+          new PipelinePlugin,
+          new MemoryPlugin(rom),
+          new FetchPlugin,
+          new DummyTimerPlugin,
+          new DummyFpuPlugin,
+          new ExecutePlugin,
+          new SchedulerPlugin
+        )
+        PluginHost(host).on {
           new T800(host, p)
         }
       }

--- a/src/test/scala/t800/TimerEnableSpec.scala
+++ b/src/test/scala/t800/TimerEnableSpec.scala
@@ -31,9 +31,9 @@ class TimerEnableSpec extends AnyFunSuite {
   test("counters pause and resume") {
     SimConfig
       .compile {
-        PluginHost.on {
-          val host = new PluginHost
-          val plugins = Seq(new TimerPlugin, new TimerProbePlugin)
+        val host = new PluginHost
+        val plugins = Seq(new TimerPlugin, new TimerProbePlugin)
+        PluginHost(host).on {
           new T800(host, plugins)
         }
       }


### PR DESCRIPTION
### What & Why
* Ensure `T800` instances are built with an active `PluginHost` scope.
* Updated all test benches to apply `PluginHost(host).on` when instantiating `T800`.

### Validation
- [x] `sbt scalafmtAll`
- [x] `sbt test` *(fails: SpinalHDL async engine stuck)*

------
https://chatgpt.com/codex/tasks/task_e_684c941cdcac8325903b002ccaec805a