### PR TITLE
Implement RUNP and STOPP

### DIFF
--- a/src/main/scala/t800/Opcodes.scala
+++ b/src/main/scala/t800/Opcodes.scala
@@ -247,8 +247,8 @@ object Opcodes {
       val REV, LB, ADD, IN, OUT, SUB, STARTP, OUTBYTE, OUTWORD, STLB, STHF, LDPI, STLF, RET,
         LDTIMER, TESTERR, XOR, SHR, SHL, MINT, ALT, ALTWT, ALTEND, AND, MOVE, STHB, STTIMER,
         CLRHALTERR, SETHALTERR, TESTHALTERR, DUP, MOVE2DINIT, MOVE2DALL, MOVE2DNONZERO, MOVE2DZERO,
-        POP, TIMERDISABLEH, TIMERDISABLEL, TIMERENABLEH, TIMERENABLEL, FPADD, FPSUB, FPMUL, FPDIV =
-        newElement()
+        POP, TIMERDISABLEH, TIMERDISABLEL, TIMERENABLEH, TIMERENABLEL, RUNP, STOPP, FPADD, FPSUB,
+        FPMUL, FPDIV = newElement()
       defaultEncoding = SpinalEnumEncoding("static")(
         REV -> 0x00,
         LB -> 0x01,
@@ -290,6 +290,8 @@ object Opcodes {
         TIMERDISABLEL -> 0x7b,
         TIMERENABLEH -> 0x7c,
         TIMERENABLEL -> 0x7d,
+        RUNP -> 0x39,
+        STOPP -> 0x15,
         FPADD -> 0x87,
         FPSUB -> 0x89,
         FPMUL -> 0x8b,

--- a/src/main/scala/t800/plugins/ExecutePlugin.scala
+++ b/src/main/scala/t800/plugins/ExecutePlugin.scala
@@ -148,6 +148,11 @@ class ExecutePlugin extends FiberPlugin {
             stack.A := stack.B
             stack.B := stack.C
           }
+          is(Opcodes.Enum.Secondary.RUNP) {
+            sched.enqueue(stack.A, False)
+            stack.A := stack.B
+            stack.B := stack.C
+          }
           is(Opcodes.Enum.Secondary.TESTERR) {
             val tmp = errReg
             errReg := False
@@ -183,6 +188,10 @@ class ExecutePlugin extends FiberPlugin {
             hiFPtr := stack.A
             stack.A := stack.B
             stack.B := stack.C
+          }
+          is(Opcodes.Enum.Secondary.STOPP) {
+            sched.enqueue(stack.WPtr, False)
+            pipe.execute.haltWhen(True)
           }
           is(Opcodes.Enum.Secondary.MINT) {
             stack.C := stack.B

--- a/src/main/scala/t800/plugins/SchedulerPlugin.scala
+++ b/src/main/scala/t800/plugins/SchedulerPlugin.scala
@@ -32,6 +32,11 @@ class SchedulerPlugin extends FiberPlugin {
     addService(new SchedSrv {
       override def newProc: Flow[SchedCmd] = cmdReg
       override def nextProc: UInt = nextReg
+      override def enqueue(ptr: UInt, high: Bool): Unit = {
+        cmdReg.valid := True
+        cmdReg.payload.ptr := ptr
+        cmdReg.payload.high := high
+      }
     })
     retain()
     println(s"[${SchedulerPlugin.this.getDisplayName()}] setup end")

--- a/src/main/scala/t800/plugins/Services.scala
+++ b/src/main/scala/t800/plugins/Services.scala
@@ -45,6 +45,7 @@ case class SchedCmd() extends Bundle {
 trait SchedSrv {
   def newProc: Flow[SchedCmd]
   def nextProc: UInt
+  def enqueue(ptr: UInt, high: Bool): Unit
 }
 
 trait TimerSrv {

--- a/src/test/scala/t800/RunpStoppSpec.scala
+++ b/src/test/scala/t800/RunpStoppSpec.scala
@@ -1,0 +1,45 @@
+package t800
+
+import spinal.core._
+import spinal.core.sim._
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.lib.misc.plugin.PluginHost
+import t800.plugins._
+import t800.{DummyTimerPlugin, DummyFpuPlugin}
+
+class RunpStoppSpec extends AnyFunSuite {
+  test("RUNP enqueues A and STOPP enqueues WPtr") {
+    val romInit = Seq.fill(16)(BigInt(0))
+    // bytes: RUNP, STOPP, 0, 0
+    val word0 = BigInt(0x00001539L)
+    val rom = romInit.updated(0, word0)
+
+    SimConfig
+      .compile {
+        val host = new PluginHost
+        val plugins = Seq(
+          new StackPlugin,
+          new PipelinePlugin,
+          new MemoryPlugin(rom),
+          new FetchPlugin,
+          new DummyTimerPlugin,
+          new DummyFpuPlugin,
+          new ExecutePlugin,
+          new SchedulerPlugin
+        )
+        PluginHost(host).on(new T800(host, plugins))
+      }
+      .doSim { dut =>
+        dut.clockDomain.forkStimulus(10)
+        val stack = dut.host[StackSrv]
+        val sched = dut.host[SchedSrv]
+        stack.A #= 0x1234
+        dut.clockDomain.waitSampling(15)
+        val first = sched.nextProc.toBigInt
+        dut.clockDomain.waitSampling(30)
+        val second = sched.nextProc.toBigInt
+        assert(first == 0x1234)
+        assert(second == stack.WPtr.toBigInt)
+      }
+  }
+}


### PR DESCRIPTION
### What & Why
* Added RUNP/STOPP in `Opcodes.Enum.Secondary` and mapped to encodings
* Scheduler service exposes `enqueue` helper and plugin uses it
* ExecutePlugin now handles RUNP and STOPP via the scheduler
* Added `RunpStoppSpec` unit test

### Validation
- [x] `sbt scalafmtAll`
- [x] `sbt test` *(fails: 12 tests)*


------
https://chatgpt.com/codex/tasks/task_e_684d37c137dc8325b4726679eb574b20