### PR TITLE
Implement DB primitives

### DIFF
--- a/src/main/scala/spinal/lib/misc/database/DataBase.scala
+++ b/src/main/scala/spinal/lib/misc/database/DataBase.scala
@@ -69,7 +69,7 @@ abstract class Element[T](sp: ScopeProperty[Database] = Database) extends Nameab
 class ElementValue[T](sp: ScopeProperty[Database] = Database) extends Element[T](sp) {
   def getOn(db: Database): T = db.storageGet(this)
   def set(db: Database, value: T) = db.storageUpdate(this, value)
-  override def isEmpty(db: Database): Boolean = ???
+  override def isEmpty(db: Database): Boolean = !db.storageExists(this)
 }
 
 /** Same as ElementValue, but based on the SpinalHDL Fiber API. Meaning that when we get something
@@ -106,5 +106,5 @@ class ElementLanda[T](body: => T, sp: ScopeProperty[Database] = Database)
     super.getOn(db)
   }
 
-  override def set(db: Database, value: T) = ???
+  override def set(db: Database, value: T) = db.storageUpdate(this, value)
 }

--- a/src/test/scala/t800/DataBaseElementSpec.scala
+++ b/src/test/scala/t800/DataBaseElementSpec.scala
@@ -1,0 +1,24 @@
+package t800
+
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.lib.misc.database.{Database, ElementLanda}
+
+class DataBaseElementSpec extends AnyFunSuite {
+  test("ElementValue isEmpty tracks storage") {
+    val db = new Database
+    val e = Database.value[Int]()
+    assert(e.isEmpty(db))
+    e.set(db, 42)
+    assert(!e.isEmpty(db))
+  }
+
+  test("ElementLanda set updates stored value") {
+    var executed = false
+    val e = Database.landa({ executed = true; 1 })
+    val db = new Database
+    e.set(db, 5)
+    assert(!executed)
+    assert(e.getOn(db) == 5)
+    assert(!executed)
+  }
+}


### PR DESCRIPTION
### What & Why
* fleshed out `ElementValue.isEmpty` and `ElementLanda.set`
* added `DataBaseElementSpec`

### Validation
- [x] `sbt scalafmtAll`
- [x] `sbt test` *(fails: 13 tests)*


------
https://chatgpt.com/codex/tasks/task_e_684d40baf8908325bae9e612088179cd