### PR TITLE
Add timer wait for ALTWT/TIN

### DIFF
--- a/src/main/scala/t800/plugins/SecondaryInstrPlugin.scala
+++ b/src/main/scala/t800/plugins/SecondaryInstrPlugin.scala
@@ -217,13 +217,15 @@ class SecondaryInstrPlugin extends FiberPlugin {
             stack.A := tmp.asUInt.resized
           }
           is(Opcodes.Enum.Secondary.ALT) {
-            // Placeholder for ALT state machine
+            // ALT setup not yet implemented
           }
           is(Opcodes.Enum.Secondary.ALTWT) {
-            // Placeholder
+            val waitDone = timer.hi >= stack.A
+            when(!waitDone) { sched.enqueue(stack.WPtr, False) }
+            pipe.execute.haltWhen(!waitDone)
           }
           is(Opcodes.Enum.Secondary.ALTEND) {
-            // Placeholder
+            // ALTEND placeholder
           }
           is(Opcodes.Enum.Secondary.STLB) {
             loBPtr := stack.A
@@ -478,6 +480,11 @@ class SecondaryInstrPlugin extends FiberPlugin {
               stack.B := stack.C
             }
           }
+        }
+        when(secondary.asBits === Opcodes.Secondary.TIN) {
+          val waitDone = timer.hi >= stack.A
+          when(!waitDone) { sched.enqueue(stack.WPtr, False) }
+          pipe.execute.haltWhen(!waitDone)
         }
         stack.O := 0
       }

--- a/src/test/scala/t800/TinAltwtSpec.scala
+++ b/src/test/scala/t800/TinAltwtSpec.scala
@@ -1,0 +1,53 @@
+package t800
+
+import spinal.core._
+import spinal.core.sim._
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.lib.misc.plugin.PluginHost
+import t800.plugins._
+
+class TinAltwtSpec extends AnyFunSuite {
+  def buildRom(opcodes: Seq[Int]): Seq[BigInt] = {
+    val bytes = opcodes.map(_.toByte)
+    val words = bytes
+      .grouped(4)
+      .map { chunk =>
+        val p = chunk.padTo(4, 0.toByte)
+        val w = (p(3) & 0xff) << 24 | (p(2) & 0xff) << 16 | (p(1) & 0xff) << 8 | (p(0) & 0xff)
+        BigInt(w & 0xffffffffL)
+      }
+      .toSeq
+    val romInit = Seq.fill(16)(BigInt(0))
+    romInit.zipWithIndex.map { case (_, i) => if (i < words.length) words(i) else BigInt(0) }
+  }
+
+  def runTest(opcode: Int): Unit = {
+    val rom = buildRom(Seq(0x48, opcode, 0x4b, 0x15))
+    SimConfig
+      .compile {
+        val host = new PluginHost
+        val plugins = Seq(
+          new StackPlugin,
+          new PipelinePlugin,
+          new MemoryPlugin(rom),
+          new FetchPlugin,
+          new DummyFpuPlugin,
+          new PrimaryInstrPlugin,
+          new SecondaryInstrPlugin,
+          new SchedulerPlugin,
+          new TimerPlugin,
+          new PipelineBuilderPlugin
+        )
+        PluginHost(host).on(new T800(host, plugins))
+      }
+      .doSim { dut =>
+        dut.clockDomain.forkStimulus(10)
+        dut.clockDomain.waitSampling(40)
+        val stack = dut.host[StackSrv]
+        assert(stack.A.toBigInt == 0x0b)
+      }
+  }
+
+  test("TIN waits for timer") { runTest(0x2b) }
+  test("ALTWT waits for timer") { runTest(0x44) }
+}


### PR DESCRIPTION
### What & Why
* Implement minimal wait logic for ALTWT and TIN instructions.
* Added TinAltwtSpec covering timer based pause.

### Validation
- [ ] sbt scalafmtAll
- [ ] sbt test (fails: SpinalHDL async engine is stuck)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684d8726f17483258a870d8f1619c9fe