### PR TITLE
[M-0c] Organize plugins by subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ t800/
 │  │     ├─ decode/             # PrimaryInstrPlugin
 │  │     ├─ execute/            # SecondaryInstrPlugin
 │  │     ├─ schedule/           # SchedulerPlugin
+│  │     ├─ fpu/                # FpuPlugin
+│  │     ├─ grouper/            # InstrGrouperPlugin
+│  │     ├─ timers/             # TimerPlugin
+│  │     ├─ transputer/         # TransputerPlugin
 │  │     └─ ...
 │  └─ test/scala/t800/
 │      ├─ T800CoreSim.scala

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val t800 = (project in file("."))
         "Param.scala",
         "Generate.scala",
         "SystemBusSrv.scala",
-        "TransputerPlugin.scala",
+        "transputer/TransputerPlugin.scala",
       )
       val srcDir = (Compile / scalaSource).value
       val selected = (srcDir ** "*.scala").get.filter(f =>

--- a/src/main/scala/t800/Param.scala
+++ b/src/main/scala/t800/Param.scala
@@ -18,7 +18,7 @@ case class Param(
 
   def pluginsArea(hartId: Int = 0) = new Area {
     val plugins = ArrayBuffer[Hostable]()
-    plugins += new t800.plugins.TransputerPlugin(
+    plugins += new t800.plugins.transputer.TransputerPlugin(
       wordBits = wordWidth,
       linkCount = linkCount
     )

--- a/src/main/scala/t800/Top.scala
+++ b/src/main/scala/t800/Top.scala
@@ -2,7 +2,7 @@ package t800
 
 import spinal.core._
 import spinal.lib.misc.plugin.PluginHost
-import t800.plugins.TransputerPlugin
+import t800.plugins.transputer.TransputerPlugin
 
 /** Variant-aware entry point used by the build scripts. */
 

--- a/src/main/scala/t800/plugins/Services.scala
+++ b/src/main/scala/t800/plugins/Services.scala
@@ -26,49 +26,6 @@ trait StackSrv {
   def write(offset: SInt, data: UInt): Unit
 }
 
-/** Service for floating-point unit operations. */
-trait FpuSrv {
-  def pipe: Flow[FpCmd]
-  def rsp: Flow[UInt]
-
-  /** Issue a new FPU command. */
-  def send(op: FpOp.E, a: UInt, b: UInt): Unit = {
-    pipe.valid := True
-    pipe.payload.op := op
-    pipe.payload.opa := a
-    pipe.payload.opb := b
-  }
-
-  /** Result of the previously issued command. */
-  def result: UInt = rsp.payload
-
-  /** True when a result is available. */
-  def resultValid: Bool = rsp.valid
-}
-
-
-/** Service for timer management, integrated with TimerPlugin. */
-trait TimerSrv {
-  def hi: UInt
-  def lo: UInt
-
-  /** Request to set the timers to a new value. */
-  def set(value: UInt): Unit
-
-  /** Resume the high priority counter. */
-  def enableHi(): Unit
-
-  /** Resume the low priority counter. */
-  def enableLo(): Unit
-
-  /** Halt the high priority counter. */
-  def disableHi(): Unit
-
-  /** Halt the low priority counter. */
-  def disableLo(): Unit
-}
-
-
 /** Service for data bus operations, integrated with MainCachePlugin and PmiPlugin. */
 trait DataBusSrv {
   def rdCmd: Flow[t800.MemReadCmd] // BMB-based read command
@@ -149,13 +106,4 @@ trait ChannelPinsSrv {
 
 trait ChannelDmaSrv {
   def cmd: Stream[ChannelTxCmd]
-}
-
-case class GroupedInstructions() extends Bundle {
-  val instructions = Vec(Bits(t800.Global.OPCODE_BITS bits), 8)
-  val count = UInt(4 bits)
-}
-
-trait GroupedInstrSrv {
-  def groups: Flow[GroupedInstructions]
 }

--- a/src/main/scala/t800/plugins/cache/MainCachePlugin.scala
+++ b/src/main/scala/t800/plugins/cache/MainCachePlugin.scala
@@ -2,12 +2,14 @@ package t800.plugins.cache
 
 import spinal.core._
 import spinal.core.fiber._
+import spinal.lib._
 import spinal.lib.misc.plugin._
 import spinal.lib.misc.pipeline._
 import spinal.lib.misc.database._
 import spinal.lib.bus.bmb.{Bmb, BmbParameter, BmbAccessParameter, BmbOnChipRamMultiPort, BmbUnburstify, BmbArbiter, BmbDecoder, BmbDownSizerBridge}
 import t800.plugins.pmi.PmiPlugin
 import t800.plugins.{AddressTranslationSrv, WorkspaceCacheSrv}
+import t800.plugins.cache.CacheAccessSrv
 import spinal.lib.bus.misc.{AddressMapping, SizeMapping}
 
 // The MainCachePlugin implements four BmbOnChipRamMultiPort banks (4 KB each, 32-bit data/32-bit address, two read ports)
@@ -34,6 +36,13 @@ class MainCachePlugin extends FiberPlugin {
       def read(addr: Bits): Bits = srv.service.dataOut // placeholder
       def write(addr: Bits, data: Bits): Unit = {}
     })
+    val cacheIf = new CacheAccessSrv {
+      override val req = Flow(CacheReq())
+      override val rsp = Flow(CacheRsp())
+    }
+    cacheIf.req.setIdle()
+    cacheIf.rsp.setIdle()
+    addService(cacheIf)
   }
 
   buildBefore(

--- a/src/main/scala/t800/plugins/cache/Service.scala
+++ b/src/main/scala/t800/plugins/cache/Service.scala
@@ -1,6 +1,7 @@
 package t800.plugins.cache
 
 import spinal.core._
+import spinal.lib._
 
 case class WorkspaceCacheAccessSrv() extends Bundle {
   val addrA = Bits(32 bits)
@@ -23,3 +24,19 @@ case class MainCacheAccessSrv() extends Bundle {
 }
 trait MainCacheSrv { def read(addr: Bits): Bits; def write(addr: Bits, data: Bits): Unit }
 trait WorkspaceCacheSrv { def write(addr: Bits, data: Bits): Unit; def fetch(addr: Bits): Bits }
+
+case class CacheReq() extends Bundle {
+  val addr  = Bits(32 bits)
+  val data  = Bits(32 bits)
+  val write = Bool()
+}
+
+case class CacheRsp() extends Bundle {
+  val data = Bits(32 bits)
+  val hit  = Bool()
+}
+
+trait CacheAccessSrv {
+  def req: Flow[CacheReq]
+  def rsp: Flow[CacheRsp]
+}

--- a/src/main/scala/t800/plugins/cache/WorkspaceCachePlugin.scala
+++ b/src/main/scala/t800/plugins/cache/WorkspaceCachePlugin.scala
@@ -2,11 +2,13 @@ package t800.plugins.cache
 
 import spinal.core._
 import spinal.core.fiber._
+import spinal.lib._
 import spinal.lib.misc.plugin._
 import spinal.lib.misc.pipeline._
 import spinal.lib.misc.database._
 import spinal.lib.bus.bmb.{Bmb, BmbParameter, BmbAccessParameter, BmbOnChipRamMultiPort}
 import t800.plugins.{AddressTranslationSrv, MainCacheSrv}
+import t800.plugins.cache.CacheAccessSrv
 import spinal.lib.bus.misc.SingleMapping
 
 // The WorkspaceCachePlugin implements a 32-word triple-ported cache (two reads, one write per cycle)
@@ -33,6 +35,13 @@ class WorkspaceCachePlugin extends FiberPlugin {
   lazy val srv = during setup new Area {
     val service = WorkspaceCacheAccessSrv()
     addService(service)
+    val cacheIf = new CacheAccessSrv {
+      override val req = Flow(CacheReq())
+      override val rsp = Flow(CacheRsp())
+    }
+    cacheIf.req.setIdle()
+    cacheIf.rsp.setIdle()
+    addService(cacheIf)
   }
 
   buildBefore(retains(host[MainCachePlugin].lock).lock)

--- a/src/main/scala/t800/plugins/execute/SecondaryInstrPlugin.scala
+++ b/src/main/scala/t800/plugins/execute/SecondaryInstrPlugin.scala
@@ -8,6 +8,8 @@ import spinal.core.fiber.Retainer
 import t800.{Opcodes, Global}
 import t800.plugins.{ChannelSrv, ChannelTxCmd, LinkBusSrv, LinkBusArbiterSrv}
 import t800.plugins.schedule.SchedSrv
+import t800.plugins.fpu.FpuSrv
+import t800.plugins.timers.TimerSrv
 import scala.util.Try
 
 /** Implements basic ALU instructions and connects to the global pipeline. */

--- a/src/main/scala/t800/plugins/fpu/FpuPlugin.scala
+++ b/src/main/scala/t800/plugins/fpu/FpuPlugin.scala
@@ -1,4 +1,4 @@
-package t800.plugins
+package t800.plugins.fpu
 
 import spinal.core._
 import spinal.lib._
@@ -7,6 +7,7 @@ import spinal.lib.misc.pipeline._
 import spinal.core.fiber.Retainer
 import spinal.lib.misc.plugin._
 import t800.Global
+import t800.plugins.fpu._
 
 object FpOp extends SpinalEnum {
   val ADD, SUB, MUL, DIV, INVALID = newElement()

--- a/src/main/scala/t800/plugins/fpu/Service.scala
+++ b/src/main/scala/t800/plugins/fpu/Service.scala
@@ -1,0 +1,24 @@
+package t800.plugins.fpu
+
+import spinal.core._
+import spinal.lib._
+import t800.Global
+
+trait FpuSrv {
+  def pipe: Flow[FpCmd]
+  def rsp: Flow[UInt]
+
+  /** Issue a new FPU command. */
+  def send(op: FpOp.E, a: UInt, b: UInt): Unit = {
+    pipe.valid := True
+    pipe.payload.op := op
+    pipe.payload.opa := a
+    pipe.payload.opb := b
+  }
+
+  /** Result of the previously issued command. */
+  def result: UInt = rsp.payload
+
+  /** True when a result is available. */
+  def resultValid: Bool = rsp.valid
+}

--- a/src/main/scala/t800/plugins/grouper/InstrGrouperPlugin.scala
+++ b/src/main/scala/t800/plugins/grouper/InstrGrouperPlugin.scala
@@ -1,4 +1,4 @@
-package t800.plugins
+package t800.plugins.grouper
 
 import spinal.core._
 import spinal.lib._
@@ -7,6 +7,7 @@ import spinal.lib.misc.pipeline
 import spinal.lib.misc.pipeline._
 import spinal.core.fiber.Retainer
 import t800.Global
+import t800.plugins.grouper._
 
 /** Gather opcodes from the fetch stage and deliver them in groups of up to eight instructions on
   * the decode stage. Other plugins may read the grouped values through [[GroupedInstrSrv]].

--- a/src/main/scala/t800/plugins/grouper/Service.scala
+++ b/src/main/scala/t800/plugins/grouper/Service.scala
@@ -1,0 +1,14 @@
+package t800.plugins.grouper
+
+import spinal.core._
+import spinal.lib._
+import t800.Global
+
+case class GroupedInstructions() extends Bundle {
+  val instructions = Vec(Bits(Global.OPCODE_BITS bits), 8)
+  val count = UInt(4 bits)
+}
+
+trait GroupedInstrSrv {
+  def groups: Flow[GroupedInstructions]
+}

--- a/src/main/scala/t800/plugins/timers/Service.scala
+++ b/src/main/scala/t800/plugins/timers/Service.scala
@@ -1,0 +1,23 @@
+package t800.plugins.timers
+
+import spinal.core._
+
+trait TimerSrv {
+  def hi: UInt
+  def lo: UInt
+
+  /** Request to set the timers to a new value. */
+  def set(value: UInt): Unit
+
+  /** Resume the high priority counter. */
+  def enableHi(): Unit
+
+  /** Resume the low priority counter. */
+  def enableLo(): Unit
+
+  /** Halt the high priority counter. */
+  def disableHi(): Unit
+
+  /** Halt the low priority counter. */
+  def disableLo(): Unit
+}

--- a/src/main/scala/t800/plugins/timers/TimerPlugin.scala
+++ b/src/main/scala/t800/plugins/timers/TimerPlugin.scala
@@ -1,4 +1,4 @@
-package t800.plugins
+package t800.plugins.timers
 
 import spinal.core._
 import spinal.lib._
@@ -6,6 +6,7 @@ import spinal.core.sim._
 import spinal.core.fiber.Retainer
 import spinal.lib.misc.plugin._
 import t800.Global
+import t800.plugins.timers._
 
 /** Simple high/low priority timers. High increments every cycle; low every 64 cycles. */
 class TimerPlugin extends FiberPlugin {

--- a/src/main/scala/t800/plugins/transputer/Service.scala
+++ b/src/main/scala/t800/plugins/transputer/Service.scala
@@ -1,0 +1,4 @@
+package t800.plugins.transputer
+
+/** Placeholder for Transputer-specific services. */
+trait TransputerService

--- a/src/main/scala/t800/plugins/transputer/TransputerPlugin.scala
+++ b/src/main/scala/t800/plugins/transputer/TransputerPlugin.scala
@@ -1,4 +1,4 @@
-package t800.plugins
+package t800.plugins.transputer
 
 import spinal.core._
 import spinal.lib.misc.database.{Database, Element}

--- a/src/test/scala/t800/ChannelDmaSpec.scala
+++ b/src/test/scala/t800/ChannelDmaSpec.scala
@@ -8,6 +8,7 @@ import t800.plugins._
 import spinal.lib.misc.plugin.PluginHost
 import t800.plugins.schedule.SchedulerPlugin
 import t800.{DummyTimerPlugin, DummyFpuPlugin}
+import t800.plugins.grouper.GrouperPlugin
 
 class ChannelDmaSpec extends AnyFunSuite {
   test("DMA opcode transfers bytes") {

--- a/src/test/scala/t800/FpuPluginSpec.scala
+++ b/src/test/scala/t800/FpuPluginSpec.scala
@@ -5,6 +5,7 @@ import spinal.core.sim._
 import spinal.lib.misc.database.Database
 import org.scalatest.funsuite.AnyFunSuite
 import t800.plugins._
+import t800.plugins.fpu._
 import spinal.lib.misc.plugin.PluginHost
 
 class FpuDut extends Component {

--- a/src/test/scala/t800/GlobalDatabaseSpec.scala
+++ b/src/test/scala/t800/GlobalDatabaseSpec.scala
@@ -5,6 +5,7 @@ import spinal.core.sim._
 import spinal.lib.misc.database.Database
 import org.scalatest.funsuite.AnyFunSuite
 import t800.plugins._
+import t800.plugins.timers.TimerPlugin
 import spinal.lib.misc.plugin.PluginHost
 
 class GlobalDatabaseSpec extends AnyFunSuite {

--- a/src/test/scala/t800/GrouperPluginSpec.scala
+++ b/src/test/scala/t800/GrouperPluginSpec.scala
@@ -4,6 +4,7 @@ import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
 import t800.plugins._
+import t800.plugins.grouper.GrouperPlugin
 import spinal.lib.misc.plugin.PluginHost
 
 class GrouperPluginSpec extends AnyFunSuite {

--- a/src/test/scala/t800/HelloWorldSim.scala
+++ b/src/test/scala/t800/HelloWorldSim.scala
@@ -5,6 +5,8 @@ import spinal.core.sim._
 import t800.plugins._
 import spinal.lib.misc.plugin.PluginHost
 import t800.plugins.schedule.SchedulerPlugin
+import t800.plugins.timers.TimerPlugin
+import t800.plugins.grouper.GrouperPlugin
 
 object HelloWorldSim {
 

--- a/src/test/scala/t800/HelloWorldSpec.scala
+++ b/src/test/scala/t800/HelloWorldSpec.scala
@@ -6,6 +6,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import t800.plugins._
 import spinal.lib.misc.plugin.PluginHost
 import t800.plugins.schedule.SchedulerPlugin
+import t800.plugins.timers.TimerPlugin
+import t800.plugins.grouper.GrouperPlugin
 
 class HelloWorldSpec extends AnyFunSuite {
   ignore("ROM program prints hello world") {

--- a/src/test/scala/t800/Move2DSpec.scala
+++ b/src/test/scala/t800/Move2DSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import t800.plugins._
 import spinal.lib.misc.plugin.PluginHost
 import t800.plugins.schedule.SchedulerPlugin
+import t800.plugins.grouper.GrouperPlugin
 
 class Move2DSpec extends AnyFunSuite {
   test("MOVE2DALL transfers 2D bytes") {

--- a/src/test/scala/t800/OprLdlSpec.scala
+++ b/src/test/scala/t800/OprLdlSpec.scala
@@ -9,6 +9,7 @@ import t800.plugins.schedule.SchedulerPlugin
 import spinal.lib.misc.plugin.PluginHost
 
 import t800.{DummyTimerPlugin, DummyFpuPlugin}
+import t800.plugins.grouper.GrouperPlugin
 
 class OprLdlSpec extends AnyFunSuite {
   test("LDL loads from workspace") {

--- a/src/test/scala/t800/OprStlSpec.scala
+++ b/src/test/scala/t800/OprStlSpec.scala
@@ -8,6 +8,7 @@ import spinal.lib._
 import t800.plugins.schedule.SchedulerPlugin
 import spinal.lib.misc.plugin.PluginHost
 import t800.{DummyTimerPlugin, DummyFpuPlugin}
+import t800.plugins.grouper.GrouperPlugin
 
 class OprStlSpec extends AnyFunSuite {
   test("STL stores A and updates stack") {

--- a/src/test/scala/t800/PrefixSpec.scala
+++ b/src/test/scala/t800/PrefixSpec.scala
@@ -7,6 +7,7 @@ import t800.plugins._
 import spinal.lib.misc.plugin.PluginHost
 import t800.plugins.schedule.SchedulerPlugin
 import t800.{DummyTimerPlugin, DummyFpuPlugin}
+import t800.plugins.grouper.GrouperPlugin
 
 class PrefixSpec extends AnyFunSuite {
   test("PFIX/NFIX build literals") {

--- a/src/test/scala/t800/RunpStoppSpec.scala
+++ b/src/test/scala/t800/RunpStoppSpec.scala
@@ -7,6 +7,7 @@ import spinal.lib.misc.plugin.PluginHost
 import t800.plugins._
 import t800.{DummyTimerPlugin, DummyFpuPlugin}
 import t800.plugins.schedule.{SchedulerPlugin, SchedSrv}
+import t800.plugins.grouper.GrouperPlugin
 
 class RunpStoppSpec extends AnyFunSuite {
   test("RUNP enqueues A and STOPP enqueues WPtr") {

--- a/src/test/scala/t800/SchedulerSaveSpec.scala
+++ b/src/test/scala/t800/SchedulerSaveSpec.scala
@@ -7,6 +7,7 @@ import spinal.lib.misc.plugin.PluginHost
 import t800.plugins._
 import t800.{DummyTimerPlugin, DummyFpuPlugin}
 import t800.plugins.schedule.{SchedulerPlugin, SchedSrv}
+import t800.plugins.grouper.GrouperPlugin
 
 class SchedulerSaveSpec extends AnyFunSuite {
   test("LEND re-enqueues current workspace") {

--- a/src/test/scala/t800/TestPlugins.scala
+++ b/src/test/scala/t800/TestPlugins.scala
@@ -4,6 +4,8 @@ import spinal.core._
 import spinal.lib._
 import spinal.lib.misc.plugin.FiberPlugin
 import t800.plugins._
+import t800.plugins.fpu.FpuSrv
+import t800.plugins.timers.TimerSrv
 
 /** Minimal timer plugin exposing [[TimerSrv]] without any logic. */
 class DummyTimerPlugin extends FiberPlugin {

--- a/src/test/scala/t800/TimerEnableSpec.scala
+++ b/src/test/scala/t800/TimerEnableSpec.scala
@@ -4,6 +4,7 @@ import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
 import t800.plugins._
+import t800.plugins.timers.TimerSrv
 import t800.Global
 import spinal.lib.misc.plugin.{PluginHost, FiberPlugin, Plugin}
 

--- a/src/test/scala/t800/TinAltwtSpec.scala
+++ b/src/test/scala/t800/TinAltwtSpec.scala
@@ -5,6 +5,8 @@ import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
 import spinal.lib.misc.plugin.PluginHost
 import t800.plugins._
+import t800.plugins.timers.TimerPlugin
+import t800.plugins.grouper.GrouperPlugin
 
 import t800.plugins.schedule.SchedulerPlugin
 class TinAltwtSpec extends AnyFunSuite {


### PR DESCRIPTION
### What & Why
- Moved major plugins into dedicated subfolders with local `Service.scala`
- Updated imports for new packages and documented the folders in the README

### Validation
- `sbt scalafmtAll`
- `sbt 'testOnly t800.InitTransputerSpec'` *(fails: async engine stuck)*

------
https://chatgpt.com/codex/tasks/task_e_684ddfaf9b908325a7fdbf164416067a