### PR TITLE
[M-0d] Minimal pipeline build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,9 @@ lazy val t800 = (project in file("."))
         "Param.scala",
         "Generate.scala",
         "SystemBusSrv.scala",
+        "Services.scala",
+        "PipelinePlugin.scala",
+        "PipelineBuilderPlugin.scala",
         "transputer/TransputerPlugin.scala",
       )
       val srcDir = (Compile / scalaSource).value

--- a/src/main/scala/t800/Global.scala
+++ b/src/main/scala/t800/Global.scala
@@ -67,21 +67,13 @@ object Global extends AreaObject {
   val Link1Output = 0x80000004L
   val Link0Output = 0x80000000L
 
-  // Pipeline payloads
-  def IPTR: Payload[UInt] = Payload(UInt(IPTR_BITS bits))
-  def OPCODE: Payload[Bits] = Payload(Bits(OPCODE_BITS bits))
-  def MEM_ADDR: Payload[UInt] = Payload(UInt(ADDR_BITS bits))
-  def MEM_DATA: Payload[Bits] = Payload(Bits(WORD_BITS bits))
+  // Pipeline payloads (using defaults to avoid database dependency)
+  def IPTR: Payload[UInt] = Payload(UInt(AddrBitsValue bits))
+  def OPCODE: Payload[Bits] = Payload(Bits(8 bits))
+  def MEM_ADDR: Payload[UInt] = Payload(UInt(AddrBitsValue bits))
+  def MEM_DATA: Payload[Bits] = Payload(Bits(WordBits bits))
 
   // Memory command definitions, aligned with T9000
-  case class MemWriteCmd[T <: Data](
-    payloadType: HardType[T] = HardType(Bits(WORD_BITS bits)),
-    depth: Int = 1 << AddrBits
-  ) extends Bundle {
-    val address = UInt(log2Up(depth) bits)
-    val data = payloadType()
-  }
-
   case class MemRead[T <: Data](
     payloadType: HardType[T] = HardType(Bits(WORD_BITS bits)),
     depth: Int = 1 << AddrBits
@@ -279,4 +271,14 @@ object Global extends AreaObject {
       isValid := !WriteLock.isLocked(addr)
     }
   }
+}
+
+// Minimal memory command bundles used across services
+case class MemWriteCmd(depth: Int = 1 << Global.AddrBits) extends Bundle {
+  val address = UInt(log2Up(depth) bits)
+  val data = Bits(Global.WORD_BITS bits)
+}
+
+case class MemReadCmd(depth: Int = 1 << Global.AddrBits) extends Bundle {
+  val address = UInt(log2Up(depth) bits)
 }

--- a/src/main/scala/t800/T800.scala
+++ b/src/main/scala/t800/T800.scala
@@ -6,6 +6,7 @@ import spinal.lib.misc.database.Database
 import spinal.lib.misc.plugin.{PluginHost, FiberPlugin, Hostable}
 import spinal.lib.bus.bmb.{Bmb, BmbParameter, BmbAccessParameter}
 import t800.SystemBusSrv
+import t800.plugins._
 
 object T800 {
 
@@ -25,7 +26,8 @@ object T800 {
   def defaultPlugins(): Seq[FiberPlugin] = Param().plugins()
 
   /** Minimal plugin set used by unit tests. */
-  def unitPlugins(): Seq[FiberPlugin] = Param().plugins()
+  def unitPlugins(): Seq[FiberPlugin] =
+    Seq(new transputer.TransputerPlugin(), new PipelinePlugin, new PipelineBuilderPlugin)
 
   /** Convenience constructor returning an empty T800. */
   def apply(): T800 = new T800(Database.get)

--- a/src/main/scala/t800/plugins/PipelinePlugin.scala
+++ b/src/main/scala/t800/plugins/PipelinePlugin.scala
@@ -27,7 +27,6 @@ class PipelinePlugin extends FiberPlugin {
   private var executeReg: CtrlLink = null
   private var memoryReg: CtrlLink = null
   private var writeBackReg: CtrlLink = null
-  private val retain = Retainer()
 
   during setup new Area {
     report(L"Initializing $version")
@@ -47,7 +46,6 @@ class PipelinePlugin extends FiberPlugin {
       stage(Global.MEM_ADDR)
       stage(Global.MEM_DATA)
     }
-    retain()
     println(s"[${PipelinePlugin.this.getDisplayName()}] setup end")
   }
   def fetch: CtrlLink = fetchReg
@@ -62,7 +60,6 @@ class PipelinePlugin extends FiberPlugin {
 
   during build new Area {
     println(s"[${PipelinePlugin.this.getDisplayName()}] build start")
-    retain.await()
     pipeline.build()
     addService(new PipelineSrv {
       override def fetch = fetchReg

--- a/src/main/scala/t800/plugins/Services.scala
+++ b/src/main/scala/t800/plugins/Services.scala
@@ -49,16 +49,12 @@ trait LinkBusArbiterSrv {
 }
 
 /** Service for memory access, removed direct Mem access, integrated with BMB plugins. */
-trait MemAccessSrv {
-  def getCacheAccess(): t800.plugins.cache.MainCacheAccessSrv // Access MainCachePlugin service
-  def getPmiAccess(): t800.plugins.pmi.PmiAccessSrv // Access PmiPlugin service
-}
 
 /** Service for trap handling, integrated with MemoryManagementPlugin. */
 case class TrapHandlerSrv() extends Bundle {
-  val trapAddr = Bits(32 bits)      // Address where trap occurred
-  val trapType = Bits(4 bits)       // Type of trap (e.g., 0010: stack extension, 0100: privileged instr)
-  val trapEnable = Bool()           // Enable trap handling for current process
+  val trapAddr = Bits(32 bits) // Address where trap occurred
+  val trapType = Bits(4 bits) // Type of trap (e.g., 0010: stack extension, 0100: privileged instr)
+  val trapEnable = Bool() // Enable trap handling for current process
   val trapHandlerAddr = Bits(32 bits) // Address of trap handler (set by SchedulerPlugin)
   def setTrap(addr: Bits, typ: Bits): Unit = {
     trapAddr := addr
@@ -84,6 +80,7 @@ case class ChannelPins(count: Int) extends Bundle with LinkPins {
 }
 
 trait ChannelSrv {
+
   /** Return true when the transmit FIFO can accept a new word. */
   def txReady(link: UInt): Bool
 

--- a/src/test/scala/t800/InitTransputerSpec.scala
+++ b/src/test/scala/t800/InitTransputerSpec.scala
@@ -3,16 +3,14 @@ package t800
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
+import t800.plugins.PipelineSrv
 
-/** Ensure minimal T800 configuration builds with only TransputerPlugin. */
+/** Ensure minimal T800 configuration builds with basic pipeline. */
 class InitTransputerSpec extends AnyFunSuite {
   test("TransputerPlugin sets default configuration") {
     val db = T800.defaultDatabase()
-    SimConfig
-      .compile(new T800Unit(db))
-      .doSim { _ =>
-        assert(db(Global.WORD_BITS) == Global.WordBits)
-        assert(db(Global.RAM_WORDS) == Global.RamWords)
-      }
+    val report = SpinalConfig().generateVerilog(new T800Unit(db))
+    assert(db(Global.WORD_BITS) == Global.WordBits)
+    assert(db(Global.RAM_WORDS) == Global.RamWords)
   }
 }


### PR DESCRIPTION
### What & Why
- let `unitPlugins` include PipelinePlugin and PipelineBuilderPlugin
- add simple memory command bundles and default-width payloads
- strip the PipelinePlugin retainer to avoid build stalls
- trim unused services and verify core parameters in `InitTransputerSpec`

### Validation
- `sbt scalafmtAll`
- `sbt 'testOnly t800.InitTransputerSpec'`


------
https://chatgpt.com/codex/tasks/task_e_684ddfaf9b908325a7fdbf164416067a