### PR TITLE
Add FPU service trait

### DIFF
--- a/src/main/scala/t800/Opcode.scala
+++ b/src/main/scala/t800/Opcode.scala
@@ -311,6 +311,8 @@ object Opcode {
   }
 
   object SecondaryOpcode extends SpinalEnum {
+
+    // format: off
   
     // No Prefix (Table B.2)
     val REV, LB, BSUB, ENDP, DIFF, ADD, GCALL, IN, PROD, GT, WSUB, OUT, SUB, STARTP, OUTBYTE, OUTWORD,
@@ -335,6 +337,8 @@ object Opcode {
     SWAPTIMER, SWAPQUEUE, STOPCH, VOUT, VIN, SWAPBFR, SETHDR, SETCHMODE, INITVLCB, WRITEHDR, READHDR,
     DISG, ENBG, GRANT, STMOVE2DINIT, CAUSEERROR, UNMKRC, MKRC, IRDSQ, ERDSQ, STRESPTR, LDRESPTR, DEVMOVE,
     ICL, FDCL, ICA, FDCA, NOP, LDPRODID = newElement()
+
+    // format: on
 
     defaultEncoding = SpinalEnumEncoding("static")(
 	

--- a/src/main/scala/t800/plugins/execute/SecondaryInstrPlugin.scala
+++ b/src/main/scala/t800/plugins/execute/SecondaryInstrPlugin.scala
@@ -8,7 +8,7 @@ import spinal.core.fiber.Retainer
 import t800.{Opcodes, Global}
 import t800.plugins.{ChannelSrv, ChannelTxCmd, LinkBusSrv, LinkBusArbiterSrv}
 import t800.plugins.schedule.SchedSrv
-import t800.plugins.fpu.FpuSrv
+import t800.plugins.fpu.{FpuSrv, FpOp}
 import t800.plugins.timers.TimerSrv
 import t800.plugins.pipeline.PipelineSrv
 import scala.util.Try

--- a/src/main/scala/t800/plugins/fpu/Service.scala
+++ b/src/main/scala/t800/plugins/fpu/Service.scala
@@ -5,6 +5,29 @@ import spinal.lib._
 import spinal.lib.misc.pipeline._
 import t800.Global
 
+case class FpCmd() extends Bundle {
+  val op = FpOp()
+  val opa = UInt(Global.WORD_BITS bits)
+  val opb = UInt(Global.WORD_BITS bits)
+}
+
+object FpOp extends SpinalEnum {
+  val ADD, SUB, MUL, DIV = newElement()
+}
+
+trait FpuSrv {
+  def pipe: Flow[FpCmd]
+  def rsp: Flow[UInt]
+  def send(op: FpOp.E, a: UInt, b: UInt): Unit = {
+    pipe.valid := True
+    pipe.payload.op := op
+    pipe.payload.opa := a
+    pipe.payload.opb := b
+  }
+  def resultValid: Bool = rsp.valid
+  def result: UInt = rsp.payload
+}
+
 trait FpuService {
   def push(operand: Bits): Unit // Push to FA/FB
   def pushAfix(operand: AFix): Unit // Push AFix operand

--- a/src/test/scala/t800/FpuPluginSpec.scala
+++ b/src/test/scala/t800/FpuPluginSpec.scala
@@ -25,12 +25,10 @@ class FpuDut extends Component {
     plugin.awaitBuild()
   }
   val srv = host[FpuSrv]
-  srv.pipe.valid := io.cmdValid
-  srv.pipe.payload.op := io.op
-  srv.pipe.payload.opa := io.a
-  srv.pipe.payload.opb := io.b
-  io.rspValid := srv.rsp.valid
-  io.rsp := srv.rsp.payload
+  srv.pipe.valid := False
+  when(io.cmdValid) { srv.send(io.op, io.a, io.b) }
+  io.rspValid := srv.resultValid
+  io.rsp := srv.result
 }
 
 class FpuPluginSpec extends AnyFunSuite {

--- a/src/test/scala/t800/TestPlugins.scala
+++ b/src/test/scala/t800/TestPlugins.scala
@@ -43,6 +43,14 @@ class DummyFpuPlugin extends FiberPlugin {
     addService(new FpuSrv {
       override def pipe: Flow[FpCmd] = pipeReg
       override def rsp: Flow[UInt] = rspReg
+      override def send(op: FpOp.E, a: UInt, b: UInt): Unit = {
+        pipeReg.valid := True
+        pipeReg.payload.op := op
+        pipeReg.payload.opa := a
+        pipeReg.payload.opb := b
+      }
+      override def resultValid: Bool = rspReg.valid
+      override def result: UInt = rspReg.payload
     })
   }
 


### PR DESCRIPTION
### What & Why
* provide `FpOp` enum and `FpCmd` bundle
* expose new `FpuSrv` interface with helper methods
* update dummy plugin, unit test and execution plugin imports

### Validation
- [x] `sbt scalafmtAll`
- [x] `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_684f0174a708832590ff91a699b67049