### PR TITLE
Implement special helpers in FPU VCU

### DIFF
--- a/src/main/scala/t800/plugins/fpu/FpuPlugin.scala
+++ b/src/main/scala/t800/plugins/fpu/FpuPlugin.scala
@@ -115,7 +115,7 @@ class FpuPlugin extends FiberPlugin with PipelineService {
       when(vcu.io.isSpecial) {
         result := vcu.io.specialResult
         when(vcu.io.trapEnable) {
-          trap.trapType := 0x4
+          trap.trapType := vcu.io.trapType.asBits
           trap.trapAddr := pipe.execute(Fetch.FETCH_PC)
           status.errorFlags(3) := True
         }
@@ -174,7 +174,7 @@ class FpuPlugin extends FiberPlugin with PipelineService {
           // Error ops
           is(Opcodes.SecondaryEnum.FPCHKERR) {
             when(status.errorFlags.orR) {
-              trap.trapType := 0x4
+              trap.trapType := vcu.io.trapType.asBits
               trap.trapAddr := pipe.execute(Fetch.FETCH_PC)
             }
           }
@@ -318,7 +318,7 @@ class FpuPlugin extends FiberPlugin with PipelineService {
       def specialValueDetected: Bool = vcu.io.isSpecial
       def specialResult: Bits = vcu.io.specialResult
       def trapEnable: Bool = vcu.io.trapEnable
-      def trapType: UInt = 0x4
+      def trapType: UInt = vcu.io.trapType
       def roundingMode: Bits = status.roundingMode
     })
 


### PR DESCRIPTION
### What & Why
* Added helper logic in `VCU` to emit signed zero/infinity, canonical NaN and normalised denormals.
* `FpuPlugin` now relies on `VCU` provided `trapType`.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test`
- [ ] `sbt "runMain t800.TopVerilog"`


------
https://chatgpt.com/codex/tasks/task_e_684f1cc50e188325ae87a12cd10fcd11