### PR TITLE
Unify SystemBusSrv trait

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,6 @@ lazy val t800 = (project in file("."))
         "T800.scala",
         "Param.scala",
         "Generate.scala",
-        "SystemBusSrv.scala",
         "plugins/Service.scala",
         "pipeline/Service.scala",
         "plugins/registers/Service.scala",

--- a/src/main/scala/t800/SystemBusSrv.scala
+++ b/src/main/scala/t800/SystemBusSrv.scala
@@ -1,8 +1,0 @@
-package t800
-
-import spinal.core._
-import spinal.lib.bus.bmb.Bmb
-
-trait SystemBusSrv {
-  def bus: Bmb
-}

--- a/src/main/scala/t800/T800.scala
+++ b/src/main/scala/t800/T800.scala
@@ -9,7 +9,7 @@ import t800.plugins.transputer.TransputerPlugin
 import t800.plugins.pipeline.{PipelinePlugin, PipelineBuilderPlugin}
 import t800.plugins.registers.RegFilePlugin
 
-import t800.SystemBusSrv
+import t800.plugins.SystemBusSrv
 
 object T800 {
 

--- a/src/main/scala/t800/plugins/decode/PrimaryInstrPlugin.scala
+++ b/src/main/scala/t800/plugins/decode/PrimaryInstrPlugin.scala
@@ -7,7 +7,7 @@ import spinal.lib.misc.plugin.FiberPlugin
 import spinal.core.fiber.Retainer
 import spinal.lib.bus.bmb.{Bmb, BmbParameter, BmbDownSizerBridge, BmbUnburstify}
 import t800.{Global, Opcodes, T800}
-import t800.plugins.{RegfileService, Fetch, GrouperPlugin, GroupedInstrSrv}
+import t800.plugins.{RegfileService, Fetch, GrouperPlugin, GroupedInstrSrv, SystemBusSrv}
 import t800.plugins.registers.RegName
 import t800.plugins.pipeline.{PipelineService, PipelineSrv}
 
@@ -210,8 +210,4 @@ class PrimaryInstrPlugin extends FiberPlugin with PipelineService {
   }
 
   override def getLinks(): Seq[Link] = Seq()
-
-  trait SystemBusSrv {
-    def bus: Bmb
-  }
 }


### PR DESCRIPTION
### What & Why
* Centralizes `SystemBusSrv` under `t800.plugins` and removes the old copy.
* Updates `T800.scala` and `PrimaryInstrPlugin.scala` to reference the shared service.
* Cleans build list for minimal unit build.

### Validation
- [x] `sbt scalafmtAll`
- [x] `sbt test` *(fails: FpuVCUSpec)*

------
https://chatgpt.com/codex/tasks/task_e_684f2de7271c83258f951e9834ffc91f