### PR TITLE
[M-?] Add synth workflow

### DIFF
--- a/.github/workflows/synth.yml
+++ b/.github/workflows/synth.yml
@@ -1,0 +1,25 @@
+name: Synthesis
+
+on:
+  pull_request:
+
+jobs:
+  synth:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Install nextpnr/Trellis
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y nextpnr-ecp5 trellis
+      - name: sbt synth
+        run: sbt synth
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: utilization
+          path: output/utilization.rpt


### PR DESCRIPTION
### What & Why
* Add synthesis workflow that installs nextpnr/Trellis.
* Runs `sbt synth` and uploads utilization report.

### Validation
- [x] sbt scalafmtAll
- [ ] `sbt test` (full + min variants)


------
https://chatgpt.com/codex/tasks/task_e_684f2e724f8483259f789c047cd7c777