### PR TITLE
Update FPU docs

### DIFF
--- a/doc/spinalAPI.md
+++ b/doc/spinalAPI.md
@@ -187,7 +187,7 @@ Plugins exchange data through small service traits:
 | `DebugPins` | Area containing optional debug signals. |
 | `ExtMemPins` | Off-chip memory interface pins. |
 | `StackSrv` | Exposes A/B/C/O registers and workspace pointer with read/write helpers. |
-| `FpuSrv` | Command and response interface for the floating-point unit. |
+| `FpuSrv` | Command and response interface for the floating-point unit. Supports `AFix` operands via `pushAfix`, `popAfix` and `executeAfix`. |
 | `SchedSrv` | Scheduler queues and control for process dispatch. |
 | `TimerSrv` | High/low timers with load and enable controls. |
 | `InstrFetchSrv` | Instruction fetch memory request and response flows. |

--- a/src/main/scala/t800/plugins/fpu/README.md
+++ b/src/main/scala/t800/plugins/fpu/README.md
@@ -54,3 +54,20 @@ Integration
 
     Pipeline: Execute stage, parallel to PrimaryInstrPlugin and SecondaryInstrPlugin.
     Dependencies: RegFilePlugin (FPAreg, FPBreg, FPCreg), SystemBusSrv (128-bit BMB), TrapHandlerSrv.
+
+Using AFix
+
+    val fpu = host[FpuOpsSrv]
+
+    // Push fixed-point operands onto the FA/FB stack
+    fpu.pushAfix(AFix(1.0, 8 exp))
+    fpu.pushAfix(AFix(2.5, 8 exp))
+
+    // Pop the top of stack as AFix
+    val top: AFix = fpu.popAfix()
+
+    // Execute an addition using AFix operands
+    val sum: AFix = fpu.executeAfix(
+        FpOp.Arithmetic.FPADD,
+        Vec(AFix(0.5, 8 exp), AFix(1.25, 8 exp))
+    )


### PR DESCRIPTION
### What & Why
* Document AFix helpers for FPU services
* Added example usage in plugin README

### Validation
- [x] `sbt scalafmtAll`
- [x] `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_684f415b50f483259964743893c25f8e