### PR TITLE
Update pipeline service naming docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,15 @@ sbt "runMain t800.TopVerilog"
   addService(LinkPins(io.links))
   ```
 
-* All service trait names **must** end in `Srv`. Replace any older `Service`
-  suffixes accordingly (`RegfileSrv`, `FpuOpsSrv`, ...).
+* **Service naming** – traits use the `Service` suffix and clearly indicate the
+  pipeline stage or subsystem they belong to. Examples: `FetchService`,
+  `DecodeService`, `FpuControlService`.
+  * Use descriptive names and avoid abbreviations like `Srv`.
+  * Align names with the 5-stage pipeline (Fetch, Decode, Execute, Memory,
+    Writeback). For services spanning multiple stages, prepend the subsystem
+    (e.g. `FpuControlService`).
+  * Reuse existing services where possible and keep names unique to avoid
+    overlap.
 
 * Dataflow inside a plugin **must** use Pipeline DSL (`Node`, `StageLink`, `CtrlLink`), not ad-hoc `RegNext`.
 
@@ -135,20 +142,20 @@ import spinal.lib.misc.plugin._
 import spinal.lib.misc.pipeline._
 
 /** Example: free-running timer service. */
-trait TimerSrv { def now: UInt }
+trait TimerService { def now: UInt }
 
 class TimerPlugin extends FiberPlugin {
   val cnt = Reg(UInt(64 bits)) init(0)
   during.setup { cnt := cnt + 1 }
 
-  addService(new TimerSrv { def now = cnt })
+  addService(new TimerService { def now = cnt })
 }
 ```
 
 Use the service elsewhere:
 
 ```scala
-val timer = Plugin[TimerSrv]
+val timer = Plugin[TimerService]
 when(ctrl.isValid) { Areg := timer.now(31 downto 0) }
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ t800/
 
 ---
 
+## Service naming strategy
+
+SpinalHDL services describe shared functionality between plugins. To keep the
+pipeline consistent:
+
+1. **Descriptive names** – use clear names like `FetchService` or
+   `FpuControlService` that reveal purpose and stage.
+2. **Service suffix** – every trait ends with `Service`; avoid abbreviations
+   such as `Srv`.
+3. **Stage alignment** – name the service after the pipeline stage it targets
+   (Fetch, Decode, Execute, Memory, Writeback). Prefix with the subsystem name
+   if it spans multiple stages.
+4. **Avoid overlap** – reuse existing services and keep names unique.
+5. **SpinalHDL conventions** – define services in `t800.plugins.<subsystem>`
+   packages and use camelCase for methods.
+
+---
+
 ## Ubuntu setup
 
 ```bash


### PR DESCRIPTION
### What & Why
* Documented the pipeline service naming strategy in `AGENTS.md` and `README.md`.
* Updated service example to use the new `Service` suffix.

### Validation
- [x] `sbt scalafmtAll`
- [x] `sbt test`
- [ ] `sbt "runMain t800.TopVerilog"` *(failed: class not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcf2491a48325b652520e66d56e9a