### PR TITLE
Add optional FPU plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ sbt "runMain t800.Generate --word-width 32 --link-count 4 --fpu true"
 # Parameters
 --word-width    CPU data width in bits
 --link-count    Number of communication links
---fpu           Enable the floating-point unit
+--fpu           Enable or disable the floating-point unit (Generate.scala flag)
 
 # To build against the bundled SpinalHDL sources instead of published
 # artifacts, run with `SPINALHDL_FROM_SOURCE=1`:

--- a/src/main/scala/t800/Param.scala
+++ b/src/main/scala/t800/Param.scala
@@ -22,5 +22,7 @@ case class Param(
       wordBits = wordWidth,
       linkCount = linkCount
     )
+    if (enableFpu)
+      plugins += new t800.plugins.fpu.FpuPlugin
   }
 }


### PR DESCRIPTION
### What & Why
* Param now instantiates `FpuPlugin` only when `enableFpu` is true.
* Documentation explains `--fpu` flag for Generate.scala.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test`
- [ ] `sbt "runMain t800.TopVerilog"`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684ff6dc2fa883258ccf393170a4480a