### PR TITLE
Replace FpuDut with FpuPlugin wrapper

### DIFF
--- a/src/test/scala/t800/TestPlugins.scala
+++ b/src/test/scala/t800/TestPlugins.scala
@@ -57,3 +57,21 @@ class DummyFpuPlugin extends FiberPlugin {
   // Empty build stage required for the fiber engine
   during build new Area {}
 }
+
+/** Minimal trap handler plugin exposing [[TrapHandlerSrv]]. */
+class DummyTrapPlugin extends FiberPlugin {
+  private var trap: TrapHandlerSrv = null
+  during setup new Area {
+    val addr = Reg(Bits(Global.ADDR_BITS bits)) init 0
+    val typ = Reg(Bits(4 bits)) init 0
+    val enable = Reg(Bool()) init False
+    val handler = Reg(Bits(Global.ADDR_BITS bits)) init 0
+    trap = TrapHandlerSrv()
+    trap.trapAddr := addr
+    trap.trapType := typ
+    trap.trapEnable := enable
+    trap.trapHandlerAddr := handler
+    addService(trap)
+  }
+  during build new Area {}
+}


### PR DESCRIPTION
### What & Why
* Replaced the old `FpuDut` helper with a wrapper around `FpuPlugin` using a plugin host.
* Added `DummyTrapPlugin` for tests and updated `FpuPluginSpec` to exercise the plugin through `FpuOpsSrv`.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test` *(fails: `Compilation failed`)*



------
https://chatgpt.com/codex/tasks/task_e_684ff979aec8832587b9d630c8a5ad0c