### PR TITLE
[M-x] Update range reduction

### DIFF
--- a/src/main/scala/t800/plugins/fpu/RangeReducer.scala
+++ b/src/main/scala/t800/plugins/fpu/RangeReducer.scala
@@ -6,27 +6,35 @@ import t800.plugins.fpu.Utils._
 
 class FpuRangeReducer extends Area {
   val io = new Bundle {
-    val op = in Bits(64 bits)
-    val roundingMode = in Bits(2 bits)
-    val result = out Bits(64 bits)
-    val cycles = out UInt(5 bits)
+    val op = in Bits (64 bits)
+    val roundingMode = in Bits (2 bits)
+    val result = out Bits (64 bits)
+    val cycles = out UInt (5 bits)
   }
 
-  // Parse IEEE-754 operand
-  val opParsed = parseIeee754(io.op)
-  val opAfix = AFix(opParsed.mantissa.asUInt, 52 bit, 0 exp)
+  // Operand treated as a fixed-point value. This keeps the implementation
+  // simple and allows us to perform subtraction steps on the raw bit pattern.
+  val operand = AFix(io.op.asUInt, 0 exp)
 
-  // Reduce the exponent modulo 32. This emulates the argument reduction used
-  // by the original T800 for `exp/ln` operations where the exponent is first
-  // normalised into a small range.  The number of cycles reflects how many
-  // times the exponent was divided by 32.
+  // Constant 2π encoded as a 64-bit IEEE-754 number.  The iterative reduction
+  // works on the same fixed-point representation as the input operand.
+  private val TWO_PI = AFix(U"64'h401921fb54442d18", 0 exp)
 
-  val exp = opParsed.exponent
-  val shift = (exp >> 5).asSInt        // division by 32
-  val reducedExp = exp - (shift << 5)  // exponent modulo 32
+  // Iterative subtraction: subtract or add 2π until the remainder is within
+  // the 0 … 2π range.  The cycle counter reflects the number of adjustments.
+  val remainder = Reg(AFix(U(0), 0 exp)) init operand
+  val cycleCnt = Reg(UInt(5 bits)) init 0
 
-  val rounded = roundIeee754(opAfix, io.roundingMode)
+  when(remainder >= TWO_PI) {
+    remainder := remainder - TWO_PI
+    cycleCnt := cycleCnt + 1
+  } elsewhen (remainder < AFix(0, 0 exp)) {
+    remainder := remainder + TWO_PI
+    cycleCnt := cycleCnt + 1
+  }
 
-  io.result := packIeee754(opParsed.sign, reducedExp, rounded.raw)
-  io.cycles := shift.abs.asUInt.resize(5)
+  val rounded = roundIeee754(remainder, io.roundingMode)
+
+  io.result := rounded.raw
+  io.cycles := cycleCnt
 }

--- a/src/test/scala/t800/RangeReducerSpec.scala
+++ b/src/test/scala/t800/RangeReducerSpec.scala
@@ -7,10 +7,10 @@ import t800.plugins.fpu._
 
 class RangeReducerDut extends Component {
   val io = new Bundle {
-    val op = in Bits(64 bits)
-    val roundingMode = in Bits(2 bits)
-    val result = out Bits(64 bits)
-    val cycles = out UInt(5 bits)
+    val op = in Bits (64 bits)
+    val roundingMode = in Bits (2 bits)
+    val result = out Bits (64 bits)
+    val cycles = out UInt (5 bits)
   }
   val rr = new FpuRangeReducer
   rr.io.op := io.op
@@ -20,15 +20,27 @@ class RangeReducerDut extends Component {
 }
 
 class RangeReducerSpec extends AnyFunSuite {
-  test("exponent modulo reduction") {
+  test("pi reduction") {
     val compiled = SimConfig.compile(new RangeReducerDut)
     compiled.doSim { dut =>
       dut.clockDomain.forkStimulus(10)
-      dut.io.op #= BigInt("3ff0000000000000", 16)
+      dut.io.op #= BigInt("400921fb54442d18", 16)
       dut.io.roundingMode #= 0
       dut.clockDomain.waitSampling()
-      assert(dut.io.result.toBigInt == BigInt("001f000000000000", 16))
-      assert(dut.io.cycles.toBigInt == 31)
+      assert(dut.io.result.toBigInt == BigInt("400921fb54442d18", 16))
+      assert(dut.io.cycles.toBigInt == 0)
+    }
+  }
+
+  test("3pi/2 reduction") {
+    val compiled = SimConfig.compile(new RangeReducerDut)
+    compiled.doSim { dut =>
+      dut.clockDomain.forkStimulus(10)
+      dut.io.op #= BigInt("4012d97c7f3321d2", 16)
+      dut.io.roundingMode #= 0
+      dut.clockDomain.waitSampling()
+      assert(dut.io.result.toBigInt == BigInt("4012d97c7f3321d2", 16))
+      assert(dut.io.cycles.toBigInt == 0)
     }
   }
 }


### PR DESCRIPTION
### What & Why
* Replace exponent-based logic with simple AFix subtraction
* Added tests for `π` and `3π/2`

### Validation
- [ ] `sbt scalafmtAll`
- [ ] `sbt test` (failed: compiler errors)


------
https://chatgpt.com/codex/tasks/task_e_68500fed7c5083259d9b070da70cad90