### PR TITLE
Remove width arg from AFix constructors

### DIFF
--- a/src/main/scala/t800/plugins/fpu/Adder.scala
+++ b/src/main/scala/t800/plugins/fpu/Adder.scala
@@ -93,7 +93,7 @@ class FpuAdder extends Component {
     val normMan = (sumAdj << lz).resize(53)
     val normExpPre = expAdj - lz.asSInt
     val normExp = normExpPre.max(S(0)).min(S(0x7ff))
-    val rounded = roundIeee754(AFix(normMan, 53 bit, 0 exp), s1(ROUND))
+    val rounded = roundIeee754(AFix(normMan.resize(53), 0 exp), s1(ROUND))
     s1(RESULT) := packIeee754(signRes, normExp, rounded.raw(51 downto 0))
   }
 

--- a/src/main/scala/t800/plugins/fpu/DivRoot.scala
+++ b/src/main/scala/t800/plugins/fpu/DivRoot.scala
@@ -23,8 +23,8 @@ class FpuDivRoot extends Area {
   // Parse IEEE-754 operands
   val op1Parsed = parseIeee754(io.op1)
   val op2Parsed = parseIeee754(io.op2)
-  val op1Afix = AFix(op1Parsed.mantissa.asUInt, 56 bit, 0 exp)
-  val op2Afix = AFix(op2Parsed.mantissa.asUInt, 56 bit, 0 exp)
+  val op1Afix = AFix(op1Parsed.mantissa.asUInt.resize(56), 0 exp)
+  val op2Afix = AFix(op2Parsed.mantissa.asUInt.resize(56), 0 exp)
 
   // SRT state
   val quotient = Reg(AFix(UQ(56 bit, 0 bit))) init 0
@@ -35,8 +35,8 @@ class FpuDivRoot extends Area {
 
   // PCA storage (optimized for BRAM)
   val pcaMem = Mem(AFix(UQ(56 bit, 0 bit)), 2) // qPlus, qMinus
-  pcaMem.write(0, AFix(0, 56 bit, 0 exp)) // qPlus
-  pcaMem.write(1, AFix(0, 56 bit, 0 exp)) // qMinus
+  pcaMem.write(0, AFix(0, 0 exp)) // qPlus
+  pcaMem.write(1, AFix(0, 0 exp)) // qMinus
 
   // SRT iteration
   val partialRemainder = Reg(AFix(UQ(56 bit, 0 bit))) init remainder
@@ -63,7 +63,7 @@ class FpuDivRoot extends Area {
     partialRemainder := compressedRemainder
     remainder := compressedRemainder
 
-    quotient := (quotient <<| 1) + AFix(quotientDigit.asBits.asSInt.resize(56), 56 bit, 0 exp)
+    quotient := (quotient <<| 1) + AFix(quotientDigit.asBits.asSInt.resize(56), 0 exp)
     when(io.isSqrt) {
       when(quotientDigit === 0) {
         pcaMem.write(0, pcaMem.readAsync(0) << 1)
@@ -110,8 +110,8 @@ class FpuDivRoot extends Area {
     quotient := 0
     remainder := op1Afix
     partialRemainder := op1Afix
-    pcaMem.write(0, AFix(0, 56 bit, 0 exp))
-    pcaMem.write(1, AFix(0, 56 bit, 0 exp))
+    pcaMem.write(0, AFix(0, 0 exp))
+    pcaMem.write(1, AFix(0, 0 exp))
     iteration := 0
     io.t805State := quotient.raw
     io.cycles := 0

--- a/src/main/scala/t800/plugins/fpu/Multiplier.scala
+++ b/src/main/scala/t800/plugins/fpu/Multiplier.scala
@@ -6,14 +6,14 @@ import t800.plugins.fpu.Utils._
 
 class FpuMultiplier extends Area {
   val io = new Bundle {
-    val op1         = in Bits (64 bits)
-    val op2         = in Bits (64 bits)
-    val isAbs       = in Bool ()
-    val isSingle    = in Bool () // Single-precision flag
+    val op1 = in Bits (64 bits)
+    val op2 = in Bits (64 bits)
+    val isAbs = in Bool ()
+    val isSingle = in Bool () // Single-precision flag
     val roundingMode = in Bits (2 bits)
-    val result      = out Bits (64 bits)
-    val resultAfix  = out AFix(UQ(56 bit, 0 bit))
-    val cycles      = out UInt(2 bits)
+    val result = out Bits (64 bits)
+    val resultAfix = out AFix (UQ(56 bit, 0 bit))
+    val cycles = out UInt (2 bits)
   }
 
   // Parse IEEE-754 operands
@@ -24,8 +24,8 @@ class FpuMultiplier extends Area {
   val mant1 = ((op1Parsed.exponent === 0) ? B"0" | B"1") ## op1Parsed.mantissa
   val mant2 = ((op2Parsed.exponent === 0) ? B"0" | B"1") ## op2Parsed.mantissa
 
-  val op1Afix = AFix(mant1.asUInt, 53 bit, 0 exp)
-  val op2Afix = AFix(mant2.asUInt, 53 bit, 0 exp)
+  val op1Afix = AFix(mant1.asUInt.resize(53), 0 exp)
+  val op2Afix = AFix(mant2.asUInt.resize(53), 0 exp)
 
   when(io.isAbs) {
     io.result := packIeee754(False, op1Parsed.exponent, op1Parsed.mantissa)
@@ -45,7 +45,7 @@ class FpuMultiplier extends Area {
       3 -> RoundType.FLOOR
     )
 
-    val rounded = AFix(shifted.raw(52 downto 0).asUInt, 53 bit, 0 exp).round(0, roundType)
+    val rounded = AFix(shifted.raw(52 downto 0).asUInt.resize(53), 0 exp).round(0, roundType)
 
     val sign = op1Parsed.sign ^ op2Parsed.sign
     io.result := packIeee754(sign, exponent, rounded.raw(51 downto 0))

--- a/src/main/scala/t800/plugins/fpu/Utils.scala
+++ b/src/main/scala/t800/plugins/fpu/Utils.scala
@@ -22,8 +22,7 @@ object Utils {
     Ieee754Format(sign, exponent, mantissa)
   }
 
-  /**
-    * Parse a 32-bit IEEE‑754 value keeping the original 23-bit mantissa.
+  /** Parse a 32-bit IEEE‑754 value keeping the original 23-bit mantissa.
     */
   def parseIeee75432(value: Bits): Ieee754Format = {
     assert(value.getWidth == 32, "Input to parseIeee75432 must be 32 bits")
@@ -47,8 +46,8 @@ object Utils {
     val roundType = mode.mux(
       0 -> RoundType.ROUNDTOEVEN, // fprn
       1 -> RoundType.FLOORTOZERO, // fprz
-      2 -> RoundType.CEIL,        // fprp
-      3 -> RoundType.FLOOR        // fprm
+      2 -> RoundType.CEIL, // fprp
+      3 -> RoundType.FLOOR // fprm
     )
     mantissa.round(0, roundType)
   }
@@ -57,8 +56,8 @@ object Utils {
 
   def classifyIeee754(value: Bits): Ieee754Class = {
     val parsed = parseIeee754(value)
-    val isNaN = parsed.exponent === 0x7FF && parsed.mantissa =/= 0
-    val isInfinity = parsed.exponent === 0x7FF && parsed.mantissa === 0
+    val isNaN = parsed.exponent === 0x7ff && parsed.mantissa =/= 0
+    val isInfinity = parsed.exponent === 0x7ff && parsed.mantissa === 0
     val isDenormal = parsed.exponent === 0 && parsed.mantissa =/= 0
     val isZero = parsed.exponent === 0 && parsed.mantissa === 0
     Ieee754Class(isNaN, isInfinity, isDenormal, isZero, parsed.sign)
@@ -66,8 +65,8 @@ object Utils {
 
   def classifyIeee754Single(value: Bits): Ieee754Class = {
     val parsed = parseIeee754Single(value)
-    val isNaN = parsed.exponent === 0xFF && parsed.mantissa(51 downto 29) =/= 0
-    val isInfinity = parsed.exponent === 0xFF && parsed.mantissa(51 downto 29) === 0
+    val isNaN = parsed.exponent === 0xff && parsed.mantissa(51 downto 29) =/= 0
+    val isInfinity = parsed.exponent === 0xff && parsed.mantissa(51 downto 29) === 0
     val isDenormal = parsed.exponent === 0 && parsed.mantissa(51 downto 29) =/= 0
     val isZero = parsed.exponent === 0 && parsed.mantissa(51 downto 29) === 0
     Ieee754Class(isNaN, isInfinity, isDenormal, isZero, parsed.sign)
@@ -85,16 +84,17 @@ object Utils {
   }
 
   def real64ToReal32(value: Bits, roundMode: Bits): Bits = {
-    val afix = AFix(value.asSInt, 64 bit, 0 exp)
+    val afix = AFix(value.asSInt.resize(64), 0 exp)
     val parsed = parseIeee754(afix.raw)
     val sign = parsed.sign
     val exponent = parsed.exponent - 1023 + 127
-    val mantissa = roundIeee754(AFix(parsed.mantissa.asUInt, 52 bit, 0 exp), roundMode).raw(51 downto 29)
+    val mantissa =
+      roundIeee754(AFix(parsed.mantissa.asUInt.resize(52), 0 exp), roundMode).raw(51 downto 29)
     packIeee754Single(sign, exponent, mantissa)
   }
 
   def realToInt32(value: Bits): SInt = {
-    val afix = AFix(value.asSInt, 64 bit, 0 exp)
+    val afix = AFix(value.asSInt.resize(64), 0 exp)
     afix.asSInt.resize(32)
   }
 
@@ -115,7 +115,7 @@ object Utils {
   }
 
   def bit32ToReal64(value: Bits): Bits = {
-    val afix = AFix(value.asUInt, 32 bit, 0 exp)
+    val afix = AFix(value.asUInt.resize(32), 0 exp)
     val sign = False
     val exponent = 1023
     val mantissa = afix.raw(31 downto 0) @@ B(0, 20 bits)


### PR DESCRIPTION
### What & Why
* Drop explicit bit-width from `AFix` constructors and resize inputs instead.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test`
- [ ] `sbt "runMain t800.TopVerilog"`

Compilation fails during tests and Verilog generation.


------
https://chatgpt.com/codex/tasks/task_e_68505078fc848325b673ab1d6eef016c