### PR TITLE
Fix AFix output syntax

### DIFF
--- a/src/main/scala/t800/plugins/fpu/DivRoot.scala
+++ b/src/main/scala/t800/plugins/fpu/DivRoot.scala
@@ -15,7 +15,7 @@ class FpuDivRoot extends Area {
     val isT805Last = in Bool ()
     val roundingMode = in Bits (2 bits)
     val result = out Bits (64 bits)
-    val resultAfix = out AFix (UQ(56 bit, 0 bit))
+    val resultAfix = out(AFix(UQ(56 bit, 0 bit)))
     val cycles = out UInt (10 bits)
     val t805State = out Bits (64 bits)
   }

--- a/src/main/scala/t800/plugins/fpu/Multiplier.scala
+++ b/src/main/scala/t800/plugins/fpu/Multiplier.scala
@@ -12,7 +12,7 @@ class FpuMultiplier extends Area {
     val isSingle    = in Bool () // Single-precision flag
     val roundingMode = in Bits (2 bits)
     val result      = out Bits (64 bits)
-    val resultAfix  = out AFix(UQ(56 bit, 0 bit))
+    val resultAfix  = out(AFix(UQ(56 bit, 0 bit)))
     val cycles      = out UInt(2 bits)
   }
 


### PR DESCRIPTION
### What & Why
* Updated `DivRoot.scala` and `Multiplier.scala` to wrap `AFix` constructor in `out(...)`.

### Validation
- [x] `sbt scalafmtAll`
- [x] `sbt test` *(fails: Compilation failed)*
- [x] `sbt "runMain t800.TopVerilog"` *(fails: Compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_685046bfea5c8325b26278a7b5b21150