### PR TITLE
Fix FPU utility calls

### DIFF
--- a/src/main/scala/t800/plugins/fpu/Adder.scala
+++ b/src/main/scala/t800/plugins/fpu/Adder.scala
@@ -89,7 +89,7 @@ class FpuAdder extends Component {
     val sumAdj = Mux(ovf, rawSum >> 1, rawSum)
     val expAdj = s1(EXP) + ovf.asUInt.asSInt
 
-    val lz = sumAdj.asBits.leadingZeros()
+    val lz = CountLeadingZeroes(sumAdj.asBits)
     val normMan = (sumAdj << lz).resize(53)
     val normExpPre = expAdj - lz.asSInt
     val normExp = normExpPre.max(S(0)).min(S(0x7ff))

--- a/src/main/scala/t800/plugins/fpu/DivRoot.scala
+++ b/src/main/scala/t800/plugins/fpu/DivRoot.scala
@@ -51,11 +51,13 @@ class FpuDivRoot extends Area {
 
   when(iteration < maxIterations) {
     val top3Digits = partialRemainder.raw(55 downto 53).asSInt
-    quotientDigit := MuxCase(
-      0,
-      Seq(
-        (top3Digits >= 2) -> 1,
-        (top3Digits <= -2) -> -1
+    quotientDigit := Mux(
+      top3Digits >= 2,
+      S(1, 2 bits),
+      Mux(
+        top3Digits <= -2,
+        S(-1, 2 bits),
+        S(0, 2 bits)
       )
     )
 


### PR DESCRIPTION
### What & Why
* Use `CountLeadingZeroes` in the adder normalization stage.
* Replace the `MuxCase` selection in `DivRoot` with nested `Mux` for clarity.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test` *(fails: compilation errors in unrelated modules)*
- [ ] `sbt "runMain t800.TopVerilog"` *(fails: compilation errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68505095d0248325845b0a8b11ba080c