### PR TITLE
fix fpu multiplier closing braces

### DIFF
--- a/src/main/scala/t800/plugins/fpu/Multiplier.scala
+++ b/src/main/scala/t800/plugins/fpu/Multiplier.scala
@@ -6,14 +6,15 @@ import t800.plugins.fpu.Utils._
 
 class FpuMultiplier extends Area {
   val io = new Bundle {
-    val op1 = in Bits (64 bits)
-    val op2 = in Bits (64 bits)
-    val isAbs = in Bool ()
-    val isSingle = in Bool () // Single-precision flag
+    val op1         = in Bits (64 bits)
+    val op2         = in Bits (64 bits)
+    val isAbs       = in Bool ()
+    val isSingle    = in Bool () // Single-precision flag
     val roundingMode = in Bits (2 bits)
-    val result      = out Bits (64 bits)
-    val resultAfix  = out(AFix(UQ(56 bit, 0 bit)))
-    val cycles      = out UInt(2 bits)
+    val result       = out Bits (64 bits)
+    val resultAfix   = out(AFix(UQ(56 bit, 0 bit)))
+    val cycles       = out UInt(2 bits)
+  }
 
   // Parse IEEE-754 operands
   val op1Parsed = parseIeee754(io.op1)


### PR DESCRIPTION
## Summary
- close bundle and class in `FpuMultiplier`

## Testing
- `sbt test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509ed701d48325b6f426d9ae4e4470