### PR TITLE
FPU divider updates

### DIFF
--- a/src/main/scala/t800/plugins/fpu/FpuPlugin.scala
+++ b/src/main/scala/t800/plugins/fpu/FpuPlugin.scala
@@ -116,9 +116,9 @@ class FpuPlugin extends FiberPlugin with PipelineSrv {
       is(Opcode.SecondaryOpcode.FPADD) { opCycles := 2 }
       is(Opcode.SecondaryOpcode.FPSUB) { opCycles := 2 }
       is(Opcode.SecondaryOpcode.FPMUL) { opCycles := 3 }
-      is(Opcode.SecondaryOpcode.FPDIV) { opCycles := 15 }
-      is(Opcode.SecondaryOpcode.FPSQRT) { opCycles := 15 }
-      is(Opcode.SecondaryOpcode.FPREM) { opCycles := 529 }
+      is(Opcode.SecondaryOpcode.FPDIV) { opCycles := divRoot.io.cycles }
+      is(Opcode.SecondaryOpcode.FPSQRT) { opCycles := divRoot.io.cycles }
+      is(Opcode.SecondaryOpcode.FPREM) { opCycles := divRoot.io.cycles }
       is(Opcode.SecondaryOpcode.FPRANGE) { opCycles := 17 }
       is(B"01000001", B"01000010", B"01000011", B"5F", B"90") { opCycles := divRoot.io.cycles }
     }

--- a/src/test/scala/t800/DivRootSpec.scala
+++ b/src/test/scala/t800/DivRootSpec.scala
@@ -37,6 +37,7 @@ class DivRootSpec extends AnyFunSuite {
   private val huge = BigInt("4630000000000000", 16) // 2^100
   private val halfHuge = BigInt("4620000000000000", 16)
   private val sqrtHuge = BigInt("431000002aa7ffff", 16)
+  private val one = BigInt("3ff0000000000000", 16)
 
   private def sign(v: BigInt) = (v >> 63) & 1
   private def exp(v: BigInt) = (v >> 52) & 0x7ff
@@ -156,6 +157,20 @@ class DivRootSpec extends AnyFunSuite {
       dut.clockDomain.waitSampling(16)
       assert(dut.io.result.toBigInt == sqrtHuge)
       assert(exp(dut.io.result.toBigInt) == 0x431)
+    }
+  }
+
+  test("large exponent remainder") {
+    SimConfig.compile(new DivRootDut).doSim { dut =>
+      dut.clockDomain.forkStimulus(10)
+      dut.io.op1 #= huge
+      dut.io.op2 #= three
+      dut.io.isSqrt #= false
+      dut.io.isRem #= true
+      dut.io.roundingMode #= 0
+      dut.clockDomain.waitSampling(16)
+      assert(dut.io.result.toBigInt == one)
+      assert(exp(dut.io.result.toBigInt) == 0x3ff)
     }
   }
 }


### PR DESCRIPTION
### What & Why
* Prep work for iterative divider: exponent diff, cycle reporting
* Bump op cycle selection to read `divRoot.io.cycles`
* Added large exponent remainder testcase

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685111d2a3188325b1a05b2eb8ee4a9e