### PR TITLE
Add minimal FPU opcode suite

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,8 @@ lazy val t800 = (project in file("."))
           "RangeReducerSpec.scala",
           "FpuBusySpec.scala",
           "TestPlugins.scala",
-          "FpOpcodeSpec.scala"
+          "FpOpcodeSpec.scala",
+          "FpuOpcodeSpec.scala"
         )
         keep.flatMap(p => (srcDir ** p).get)
       },

--- a/src/main/scala/t800/Top.scala
+++ b/src/main/scala/t800/Top.scala
@@ -7,10 +7,10 @@ import t800.plugins.transputer.TransputerPlugin
 
 object TopVerilog {
   def main(args: Array[String]): Unit = {
-    
+
     // Configure Database for variant support
     val db = T800.defaultDatabase()
-    
+
     if (args.contains("--double-precision")) {
       db(Global.FPU_PRECISION) = 64
     }
@@ -25,8 +25,8 @@ object TopVerilog {
     val report = SpinalVerilog {
       Database(db).on(T800(T800.defaultPlugins()))
     }
-    
+
     println(s"Verilog generated: ${report.toplevelName}")
-    
+
   }
 }

--- a/src/main/scala/t800/plugins/cache/MainCachePlugin.scala
+++ b/src/main/scala/t800/plugins/cache/MainCachePlugin.scala
@@ -5,7 +5,16 @@ import spinal.core.fiber._
 import spinal.lib._
 import spinal.lib.misc.plugin._
 import spinal.lib.misc.pipeline._
-import spinal.lib.bus.bmb.{Bmb, BmbParameter, BmbAccessParameter, BmbOnChipRamMultiPort, BmbUnburstify, BmbArbiter, BmbDecoder, BmbDownSizerBridge}
+import spinal.lib.bus.bmb.{
+  Bmb,
+  BmbParameter,
+  BmbAccessParameter,
+  BmbOnChipRamMultiPort,
+  BmbUnburstify,
+  BmbArbiter,
+  BmbDecoder,
+  BmbDownSizerBridge
+}
 import t800.plugins.pmi.PmiPlugin
 import t800.plugins.{AddressTranslationSrv, WorkspaceCacheSrv, SystemBusSrv, Fetch}
 import t800.plugins.pipeline.PipelineStageSrv
@@ -88,9 +97,9 @@ class MainCachePlugin extends FiberPlugin {
     // Address mappings for four banks (bits 5:4)
     val bankMappings = Seq(
       SizeMapping(0x00000000L, 0x1000L), // Bank 0: addr[5:4] = 00
-      SizeMapping(0x1000L, 0x1000L),     // Bank 1: addr[5:4] = 01
-      SizeMapping(0x2000L, 0x1000L),     // Bank 2: addr[5:4] = 10
-      SizeMapping(0x3000L, 0x1000L)      // Bank 3: addr[5:4] = 11
+      SizeMapping(0x1000L, 0x1000L), // Bank 1: addr[5:4] = 01
+      SizeMapping(0x2000L, 0x1000L), // Bank 2: addr[5:4] = 10
+      SizeMapping(0x3000L, 0x1000L) // Bank 3: addr[5:4] = 11
     )
 
     // Arbiter for pipeline inputs (Fetch/Memory)
@@ -128,7 +137,9 @@ class MainCachePlugin extends FiberPlugin {
       val unburstify = Seq.fill(2)(BmbUnburstify(bmbParameter))
       decoder.io.outputs(portId) >> unburstify(0).io.input // Port 0 (primary read/write)
       unburstify(0).io.output >> ram.io.buses(0)
-      unburstify(1).io.input.cmd.valid := fetch.isValid && fetch(Fetch.FETCH_PC)(5 downto 4).asUInt === portId
+      unburstify(1).io.input.cmd.valid := fetch.isValid && fetch(Fetch.FETCH_PC)(
+        5 downto 4
+      ).asUInt === portId
       unburstify(1).io.input.cmd.opcode := 0 // Read (secondary read port)
       unburstify(1).io.input.cmd.address := fetch(Fetch.FETCH_PC)
       unburstify(1).io.input.cmd.length := 0
@@ -248,7 +259,8 @@ class MainCachePlugin extends FiberPlugin {
     // Cache banks
     val banks = for (i <- 0 until 4) yield CacheBank(i)
 
-    val cacheMode = Reg(Bits(2 bits)) init 0 // 00: Full RAM, 01: Full Cache, 10: Half RAM/Half Cache
+    val cacheMode =
+      Reg(Bits(2 bits)) init 0 // 00: Full RAM, 01: Full Cache, 10: Half RAM/Half Cache
     val isRamMode = cacheMode === 0 || (cacheMode === 2 && fetch(Fetch.FETCH_PC)(13) === 0)
 
     val bankSel = fetch(Fetch.FETCH_PC)(5 downto 4).asUInt
@@ -296,7 +308,10 @@ class MainCachePlugin extends FiberPlugin {
         } otherwise {
           fetch.haltIt()
           val mainCacheData = pmiDownSizer.io.input.rsp.data
-          banks(reqBank).write(reqAddr, mainCacheData ## mainCacheData ## mainCacheData ## mainCacheData)
+          banks(reqBank).write(
+            reqAddr,
+            mainCacheData ## mainCacheData ## mainCacheData ## mainCacheData
+          )
           cacheIf.rsp.valid := True
           cacheIf.rsp.payload.data := mainCacheData(31 downto 0)
           cacheIf.rsp.payload.valid := True

--- a/src/main/scala/t800/plugins/cache/WorkspaceCachePlugin.scala
+++ b/src/main/scala/t800/plugins/cache/WorkspaceCachePlugin.scala
@@ -107,7 +107,8 @@ class WorkspaceCachePlugin extends FiberPlugin {
     when(!srv.isHitA) {
       decode.haltWhen(True)
       // Fetch from Main Cache
-      val mainCacheData = Plugin[MainCacheSrv].read(Plugin[AddressTranslationSrv].translate(srv.addrA))
+      val mainCacheData =
+        Plugin[MainCacheSrv].read(Plugin[AddressTranslationSrv].translate(srv.addrA))
       ram.io.buses(0).cmd.opcode := 1 // Write
       ram.io.buses(0).cmd.data := mainCacheData(31 downto 0)
       validBits(srv.addrA(4 downto 0).asUInt) := True
@@ -125,7 +126,8 @@ class WorkspaceCachePlugin extends FiberPlugin {
     when(!srv.isHitB) {
       decode.haltWhen(True)
       // Fetch from Main Cache
-      val mainCacheData = Plugin[MainCacheSrv].read(Plugin[AddressTranslationSrv].translate(srv.addrB))
+      val mainCacheData =
+        Plugin[MainCacheSrv].read(Plugin[AddressTranslationSrv].translate(srv.addrB))
       ram.io.buses(1).cmd.opcode := 1 // Write
       ram.io.buses(1).cmd.data := mainCacheData(31 downto 0)
       validBits(srv.addrB(4 downto 0).asUInt) := True

--- a/src/main/scala/t800/plugins/fetch/Service.scala
+++ b/src/main/scala/t800/plugins/fetch/Service.scala
@@ -6,6 +6,6 @@ import t800.Global
 
 /** Service interface for instruction fetch, integrated with MainCachePlugin. */
 trait InstrFetchSrv {
-  def cmd: Flow[Global.MemReadCmd]  // BMB-based read command
-  def rsp: Flow[Bits]               // Response with opcodes
+  def cmd: Flow[Global.MemReadCmd] // BMB-based read command
+  def rsp: Flow[Bits] // Response with opcodes
 }

--- a/src/main/scala/t800/plugins/fpu/Service.scala
+++ b/src/main/scala/t800/plugins/fpu/Service.scala
@@ -7,15 +7,7 @@ import t800.Global
 
 // Forward simple command and operation definitions from `Opcodes.scala`.
 // This avoids duplicate type names when both files are included in the build.
-import t800.plugins.fpu.{FpCmd => OpcodeCmd, FpOp}
-
-/** Provide local aliases for command types to avoid duplicate definitions when this file and
-  * `Opcodes.scala` are both compiled.
-  */
-object FpuServiceTypes {
-  type FpCmd = OpcodeCmd
-}
-import FpuServiceTypes.FpCmd
+import t800.plugins.fpu.{FpCmd, FpOp}
 
 trait FpuSrv {
   def pipe: Flow[FpCmd]

--- a/src/main/scala/t800/plugins/schedule/Service.scala
+++ b/src/main/scala/t800/plugins/schedule/Service.scala
@@ -4,7 +4,7 @@ import spinal.core._
 import spinal.lib._
 
 case class SchedCmd() extends Bundle {
-  val ptr  = UInt(t800.Global.ADDR_BITS bits)
+  val ptr = UInt(t800.Global.ADDR_BITS bits)
   val high = Bool()
 }
 

--- a/src/test/scala/t800/FpuOpcodeSpec.scala
+++ b/src/test/scala/t800/FpuOpcodeSpec.scala
@@ -1,0 +1,75 @@
+package t800
+
+import spinal.core._
+import spinal.core.sim._
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.lib.misc.plugin.PluginHost
+import spinal.lib.misc.database.Database
+import t800.plugins.fpu._
+
+/** Execute FPU opcodes using their raw byte encoding. */
+class FpuOpcodeDut extends Component {
+  val io = new Bundle {
+    val cmdValid = in Bool ()
+    val opcode = in Bits (8 bits)
+    val a = in Bits (64 bits)
+    val b = in Bits (64 bits)
+    val rounding = in Bits (2 bits)
+    val rspValid = out Bool ()
+    val rsp = out Bits (64 bits)
+  }
+
+  val host = new PluginHost
+  val plugins = T800.unitPlugins() ++ Seq(new DummyTrapPlugin, new FpuPlugin)
+  PluginHost(host).on(Database(T800.defaultDatabase()).on(T800(plugins)))
+
+  val fpuSrv = host[FpuSrv]
+  val ctrl = host[FpuControlSrv]
+
+  when(io.cmdValid) {
+    val op = FpOp.fromOpcode(io.opcode)
+    fpuSrv.send(op, io.a.asUInt, io.b.asUInt)
+    ctrl.setRoundingMode(io.rounding)
+    ctrl.clearErrorFlags
+  }
+  io.rsp := fpuSrv.rsp.payload.asBits
+  io.rspValid := fpuSrv.rsp.valid && io.cmdValid
+}
+
+class FpuOpcodeSpec extends AnyFunSuite {
+  private def run(opc: Int, a: Double, b: Double = 0.0, rm: Int = 0): Double = {
+    var res = 0.0
+    SimConfig.compile(new FpuOpcodeDut).doSim { dut =>
+      dut.clockDomain.forkStimulus(10)
+      dut.io.cmdValid #= true
+      dut.io.opcode #= opc
+      dut.io.a #= BigInt(java.lang.Double.doubleToRawLongBits(a)) & BigInt("ffffffffffffffff", 16)
+      dut.io.b #= BigInt(java.lang.Double.doubleToRawLongBits(b)) & BigInt("ffffffffffffffff", 16)
+      dut.io.rounding #= rm
+      dut.clockDomain.waitSampling()
+      res = java.lang.Double.longBitsToDouble(dut.io.rsp.toLong)
+    }
+    res
+  }
+
+  test("FPLDNLSN loads 1.0") {
+    assert(math.abs(run(0x8e, 1.0) - 1.0) < 1e-6)
+  }
+
+  test("FPDIV divides 4.0 / 2.0") {
+    assert(math.abs(run(0x8c, 4.0, 2.0) - 2.0) < 1e-6)
+  }
+
+  test("FPRN sets rounding mode") {
+    SimConfig.compile(new FpuOpcodeDut).doSim { dut =>
+      dut.clockDomain.forkStimulus(10)
+      dut.io.cmdValid #= true
+      dut.io.opcode #= 0xd0
+      dut.io.a #= 0
+      dut.io.b #= 0
+      dut.io.rounding #= 0
+      dut.clockDomain.waitSampling()
+      assert(dut.ctrl.roundingMode.toInt == 0)
+    }
+  }
+}


### PR DESCRIPTION
### What & Why
* Include new `FpuOpcodeSpec` exercising a few FPU instructions from their raw byte encoding.
* Restore the curated source list in `build.sbt` while whitelisting the new suite.

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test` *(fails in existing FPU suites)*

------
https://chatgpt.com/codex/tasks/task_e_685111dcb88c83259b1d6e319ed1231b