### PR TITLE
Update CI to use transputer.Generate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
       - name: test
         run: sbt test
       - name: verilog
-        run: sbt "runMain t800.TopVerilog"
+        run: sbt "runMain transputer.Generate"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Guide for OpenAI Codex to assist development of the Transputer project, a Spinal
 ```bash
 sbt scalafmtAll                      # Format
 sbt test                             # Test
-sbt "runMain Generate.DefaultBoard"  # Generate Verilog
+sbt "runMain transputer.Generate"    # Generate Verilog
 ```
 
 ## Coding Rules
@@ -55,7 +55,7 @@ sbt "runMain Generate.DefaultBoard"  # Generate Verilog
 |-------|---------|
 | Style | `sbt scalafmtAll` |
 | Tests | `sbt test` |
-| Verilog | `sbt "runMain Generate.DefaultBoard"` |
+| Verilog | `sbt "runMain transputer.Generate"` |
 
 ## Simulation
 ```scala


### PR DESCRIPTION
### What & Why
- update Verilog command to `runMain transputer.Generate`
- keep docs consistent with workflow change

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test` *(failed: 100 errors)*
- [ ] `sbt "runMain transputer.Generate"` *(failed: compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68518c9420a88325b7e1fd19a3987831