### PR TITLE
refactor: update transputer namespace

### DIFF
--- a/src/main/scala/transputer/DefaultBoard.scala
+++ b/src/main/scala/transputer/DefaultBoard.scala
@@ -1,8 +1,8 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.lib._
-import t800.plugins.transputer.TransputerPlugin
+import transputer.plugins.transputer.TransputerPlugin
 
 /** Configuration for the T9000 board core. */
 case class CoreConfig(coreFrequency: IClockDomainFrequency)
@@ -49,7 +49,7 @@ class T9000Board(boardCfg: CoreConfig) extends Component {
   // Application-specific clocking area
   val coreArea = new ClockingArea(clkCtrl.coreClockDomain) {
     // Instantiate T9000 core with default plugins
-    val t9000Core = new T800(T800.defaultPlugins())
+    val t9000Core = new Transputer(Transputer.defaultPlugins())
     t9000Core.io.reset := clkCtrl.coreClockDomain.reset
     t9000Core.io.clock := clkCtrl.coreClockDomain.clock
 
@@ -61,7 +61,7 @@ class T9000Board(boardCfg: CoreConfig) extends Component {
 object T9000BoardVerilog {
   
   def main(args: Array[String]): Unit = {
-    val db = T800.defaultDatabase()
+    val db = Transputer.defaultDatabase()
     println("[Transputer] Create the Transputer for a Generic Board")
 
     // Generate Verilog with export to two folders

--- a/src/main/scala/transputer/Global.scala
+++ b/src/main/scala/transputer/Global.scala
@@ -1,11 +1,11 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.lib.misc.database.Database
 import spinal.lib.misc.pipeline._
 import spinal.lib._
 
-/** Global configuration elements and configuration register framework for T800, accessed via
+/** Global configuration elements and configuration register framework for Transputer, accessed via
   * [[Database]]. Default values are defined below for convenience, aligned with IMS T9000
   * specifications.
   */

--- a/src/main/scala/transputer/Opcode.scala
+++ b/src/main/scala/transputer/Opcode.scala
@@ -1,9 +1,9 @@
-package t800
+package transputer
 
 import spinal.core._
 
-/** Primary and secondary opcode definitions for the T800 ISA, aligned with IMS T9000 Instruction
-  * Set Manual (Appendix B).
+/** Primary and secondary opcode definitions for the Transputer ISA, aligned with IMS T9000
+  * Instruction Set Manual (Appendix B).
   */
 
 object Opcode {

--- a/src/main/scala/transputer/Param.scala
+++ b/src/main/scala/transputer/Param.scala
@@ -24,16 +24,16 @@ case class Param(
   /** Creates an area to manage plugin instances. */
   def pluginsArea(hartId: Int = 0) = new Area {
     val plugins = ArrayBuffer[Hostable]()
-    plugins += new transputer.TransputerPlugin(
+    plugins += new transputer.plugins.transputer.TransputerPlugin(
       wordBits = wordWidth,
       linkCount = linkCount
     )
     if (enableFpu)
-      plugins += new transputer.fpu.FpuPlugin
-    plugins += new transputer.pipeline.PipelinePlugin
-    plugins += new transputer.registers.RegFilePlugin
-    plugins += new transputer.mmu.MemoryManagementPlugin
-    plugins += new transputer.cache.MainCachePlugin
-    plugins += new transputer.cache.WorkspaceCachePlugin
+      plugins += new transputer.plugins.fpu.FpuPlugin
+    plugins += new transputer.plugins.pipeline.PipelinePlugin
+    plugins += new transputer.plugins.registers.RegFilePlugin
+    plugins += new transputer.plugins.mmu.MemoryManagementPlugin
+    plugins += new transputer.plugins.cache.MainCachePlugin
+    plugins += new transputer.plugins.cache.WorkspaceCachePlugin
   }
 }

--- a/src/main/scala/transputer/Transputer.scala
+++ b/src/main/scala/transputer/Transputer.scala
@@ -5,7 +5,7 @@ import spinal.lib._
 import spinal.lib.misc.database.Database
 import spinal.lib.misc.plugin.{PluginHost, FiberPlugin, Hostable}
 import spinal.lib.bus.bmb.{Bmb, BmbParameter}
-import transputer.TransputerPlugin
+import transputer.plugins.transputer.TransputerPlugin
 import transputer.pipeline.{PipelinePlugin, PipelineBuilderPlugin}
 import transputer.registers.RegFilePlugin
 import transputer.SystemBusSrv

--- a/src/main/scala/transputer/plugins/Service.scala
+++ b/src/main/scala/transputer/plugins/Service.scala
@@ -1,10 +1,10 @@
-package t800.plugins
+package transputer.plugins
 
 import spinal.core._
 import spinal.lib._
 import spinal.lib.misc.pipeline._
 import spinal.lib.bus.bmb.Bmb
-import t800.Global
+import transputer.Global
 
 trait LinkPins
 trait DebugPins extends Area
@@ -28,22 +28,22 @@ trait SystemBusSrv {
 }
 
 trait DataBusSrv {
-  def rdCmd: Flow[t800.MemReadCmd]
+  def rdCmd: Flow[transputer.MemReadCmd]
   def rdRsp: Flow[Bits]
-  def wrCmd: Flow[t800.MemWriteCmd]
+  def wrCmd: Flow[transputer.MemWriteCmd]
 }
 
 trait LinkBusSrv {
-  def rdCmd: Flow[t800.MemReadCmd]
+  def rdCmd: Flow[transputer.MemReadCmd]
   def rdRsp: Flow[Bits]
-  def wrCmd: Flow[t800.MemWriteCmd]
+  def wrCmd: Flow[transputer.MemWriteCmd]
 }
 
 trait LinkBusArbiterSrv {
-  def exeRd: Flow[t800.MemReadCmd]
-  def exeWr: Flow[t800.MemWriteCmd]
-  def chanRd: Flow[t800.MemReadCmd]
-  def chanWr: Flow[t800.MemWriteCmd]
+  def exeRd: Flow[transputer.MemReadCmd]
+  def exeWr: Flow[transputer.MemWriteCmd]
+  def chanRd: Flow[transputer.MemReadCmd]
+  def chanWr: Flow[transputer.MemWriteCmd]
 }
 
 case class ChannelTxCmd() extends Bundle {

--- a/src/main/scala/transputer/plugins/cache/MainCachePlugin.scala
+++ b/src/main/scala/transputer/plugins/cache/MainCachePlugin.scala
@@ -1,4 +1,4 @@
-package t800.plugins.cache
+package transputer.plugins.cache
 
 import spinal.core._
 import spinal.core.fiber._
@@ -15,10 +15,10 @@ import spinal.lib.bus.bmb.{
   BmbDecoder,
   BmbDownSizerBridge
 }
-import t800.plugins.pmi.PmiPlugin
-import t800.plugins.{AddressTranslationSrv, WorkspaceCacheSrv, SystemBusSrv, Fetch}
-import t800.plugins.pipeline.PipelineStageSrv
-import t800.{Global, T800}
+import transputer.plugins.pmi.PmiPlugin
+import transputer.plugins.{AddressTranslationSrv, WorkspaceCacheSrv, SystemBusSrv, Fetch}
+import transputer.plugins.pipeline.PipelineStageSrv
+import transputer.{Global, Transputer}
 
 class MainCachePlugin extends FiberPlugin {
   val version = "MainCachePlugin v1.7"
@@ -121,7 +121,7 @@ class MainCachePlugin extends FiberPlugin {
     // Down-sizer for PMI refills
     val pmiBmb = host[PmiPlugin].srv.bus
     val pmiDownSizer = BmbDownSizerBridge(
-      inputParameter = T800.systemBusParam,
+      inputParameter = Transputer.systemBusParam,
       outputParameter = bmbParameter
     )
     pmiDownSizer.io.output >> pmiBmb

--- a/src/main/scala/transputer/plugins/cache/Service.scala
+++ b/src/main/scala/transputer/plugins/cache/Service.scala
@@ -1,8 +1,8 @@
-package t800.plugins.cache
+package transputer.plugins.cache
 
 import spinal.core._
 import spinal.lib._
-import t800.Global
+import transputer.Global
 
 case class CacheReq() extends Bundle {
   val address = UInt(Global.ADDR_BITS bits)

--- a/src/main/scala/transputer/plugins/cache/WorkspaceCachePlugin.scala
+++ b/src/main/scala/transputer/plugins/cache/WorkspaceCachePlugin.scala
@@ -1,4 +1,4 @@
-package t800.plugins.cache
+package transputer.plugins.cache
 
 import spinal.core._
 import spinal.core.fiber._
@@ -7,8 +7,8 @@ import spinal.lib.misc.plugin._
 import spinal.lib.misc.pipeline._
 import spinal.lib.misc.database._
 import spinal.lib.bus.bmb.{Bmb, BmbParameter, BmbAccessParameter, BmbOnChipRamMultiPort}
-import t800.plugins.{AddressTranslationSrv, MainCacheSrv}
-import t800.plugins.cache.CacheAccessSrv
+import transputer.plugins.{AddressTranslationSrv, MainCacheSrv}
+import transputer.plugins.cache.CacheAccessSrv
 import spinal.lib.bus.misc.SingleMapping
 
 // The WorkspaceCachePlugin implements a 32-word triple-ported cache (two reads, one write per cycle)

--- a/src/main/scala/transputer/plugins/decode/PrimaryInstrPlugin.scala
+++ b/src/main/scala/transputer/plugins/decode/PrimaryInstrPlugin.scala
@@ -1,4 +1,4 @@
-package t800.plugins.decode
+package transputer.plugins.decode
 
 import spinal.core._
 import spinal.lib._
@@ -6,13 +6,13 @@ import spinal.lib.misc.pipeline._
 import spinal.lib.misc.plugin._
 import spinal.core.fiber.Retainer
 import spinal.lib.bus.bmb.{Bmb, BmbParameter, BmbAccessParameter, BmbDownSizerBridge, BmbUnburstify}
-import t800.{Global, Opcode, T800}
-import t800.plugins.registers.RegfileSrv
-import t800.plugins.Fetch
-import t800.plugins.grouper.GroupedInstrSrv
-import t800.plugins.SystemBusSrv
-import t800.plugins.registers.RegName
-import t800.plugins.pipeline.{PipelineSrv, PipelineStageSrv}
+import transputer.{Global, Opcode, Transputer}
+import transputer.plugins.registers.RegfileSrv
+import transputer.plugins.Fetch
+import transputer.plugins.grouper.GroupedInstrSrv
+import transputer.plugins.SystemBusSrv
+import transputer.plugins.registers.RegName
+import transputer.plugins.pipeline.{PipelineSrv, PipelineStageSrv}
 
 /** Implements primary instruction decoding and execution, receiving opcodes from FetchPlugin or
   * GrouperPlugin, and accessing 128-bit system bus via BMB.
@@ -51,7 +51,7 @@ class PrimaryInstrPlugin extends FiberPlugin with PipelineSrv {
     val memBmb = Bmb(memParam)
     val unburstify = BmbUnburstify(memParam)
     val downSizer = BmbDownSizerBridge(
-      inputParameter = T800.systemBusParam,
+      inputParameter = Transputer.systemBusParam,
       outputParameter = memParam
     )
     memBmb >> unburstify.io.input

--- a/src/main/scala/transputer/plugins/decode/Service.scala
+++ b/src/main/scala/transputer/plugins/decode/Service.scala
@@ -1,3 +1,3 @@
-package t800.plugins.decode
+package transputer.plugins.decode
 
 trait DecodeSrv

--- a/src/main/scala/transputer/plugins/execute/SecondaryInstrPlugin.scala
+++ b/src/main/scala/transputer/plugins/execute/SecondaryInstrPlugin.scala
@@ -1,16 +1,16 @@
-package t800.plugins.execute
+package transputer.plugins.execute
 
 import spinal.core._
 import spinal.lib._
 import spinal.lib.misc.pipeline._
 import spinal.lib.misc.plugin.{Plugin, PluginHost}
 import spinal.core.fiber.Retainer
-import t800.{Opcode, Global}
-import t800.plugins.{ChannelSrv, ChannelTxCmd, LinkBusSrv, LinkBusArbiterSrv}
-import t800.plugins.schedule.SchedSrv
-import t800.plugins.fpu.{FpuSrv, FpOp}
-import t800.plugins.timers.TimerSrv
-import t800.plugins.pipeline.PipelineStageSrv
+import transputer.{Opcode, Global}
+import transputer.plugins.{ChannelSrv, ChannelTxCmd, LinkBusSrv, LinkBusArbiterSrv}
+import transputer.plugins.schedule.SchedSrv
+import transputer.plugins.fpu.{FpuSrv, FpOp}
+import transputer.plugins.timers.TimerSrv
+import transputer.plugins.pipeline.PipelineStageSrv
 import scala.util.Try
 
 /** Implements basic ALU instructions and connects to the global pipeline. */

--- a/src/main/scala/transputer/plugins/execute/Service.scala
+++ b/src/main/scala/transputer/plugins/execute/Service.scala
@@ -1,3 +1,3 @@
-package t800.plugins.execute
+package transputer.plugins.execute
 
 trait ExecuteSrv

--- a/src/main/scala/transputer/plugins/fetch/Fetch.scala
+++ b/src/main/scala/transputer/plugins/fetch/Fetch.scala
@@ -1,9 +1,9 @@
-package t800.plugins.fetch
+package transputer.plugins.fetch
 
 import spinal.core._
 import spinal.lib.misc.pipeline.Payload
 import spinal.lib.misc.database.Database
-import t800.Global
+import transputer.Global
 
 object Fetch extends AreaObject {
   object DBKeys {

--- a/src/main/scala/transputer/plugins/fetch/FetchPlugin.scala
+++ b/src/main/scala/transputer/plugins/fetch/FetchPlugin.scala
@@ -1,4 +1,4 @@
-package t800.plugins.fetch
+package transputer.plugins.fetch
 
 import spinal.core._
 import spinal.lib._
@@ -6,12 +6,12 @@ import spinal.lib.misc.plugin.{PluginHost, FiberPlugin, Plugin}
 import spinal.lib.misc.pipeline._
 import spinal.lib.bus.bmb.{Bmb, BmbParameter, BmbAccessParameter, BmbQueue, BmbDownSizerBridge}
 import spinal.core.fiber.Retainer
-import t800.{Global, T800}
-import t800.plugins.SystemBusSrv
-import t800.plugins.registers.RegfileSrv
-import t800.plugins.registers.RegName
-import t800.plugins.fetch.Service.InstrFetchSrv
-import t800.plugins.pipeline.{PipelineSrv, PipelineStageSrv}
+import transputer.{Global, Transputer}
+import transputer.plugins.SystemBusSrv
+import transputer.plugins.registers.RegfileSrv
+import transputer.plugins.registers.RegName
+import transputer.plugins.fetch.Service.InstrFetchSrv
+import transputer.plugins.pipeline.{PipelineSrv, PipelineStageSrv}
 
 /** Instruction fetch unit with T9000-style Instruction Prefetch Buffer (IPB) supporting
   * eight-instruction dispatch.
@@ -51,9 +51,10 @@ class FetchPlugin extends FiberPlugin with PipelineSrv {
 
     // Down-sizer from 128-bit system bus to 32-bit fetch
     val downSizer = BmbDownSizerBridge(
-      inputParameter = T800.systemBusParam,
-      outputParameter =
-        BmbDownSizerBridge.outputParameterFrom(T800.systemBusParam.access, 32).toBmbParameter()
+      inputParameter = Transputer.systemBusParam,
+      outputParameter = BmbDownSizerBridge
+        .outputParameterFrom(Transputer.systemBusParam.access, 32)
+        .toBmbParameter()
     )
     systemBus >> downSizer.io.input
 

--- a/src/main/scala/transputer/plugins/fetch/Service.scala
+++ b/src/main/scala/transputer/plugins/fetch/Service.scala
@@ -1,8 +1,8 @@
-package t800.plugins.fetch
+package transputer.plugins.fetch
 
 import spinal.core._
 import spinal.lib._
-import t800.Global
+import transputer.Global
 
 /** Service interface for instruction fetch, integrated with MainCachePlugin. */
 trait InstrFetchSrv {

--- a/src/main/scala/transputer/plugins/fpu/Adder.scala
+++ b/src/main/scala/transputer/plugins/fpu/Adder.scala
@@ -1,4 +1,4 @@
-package t800.plugins.fpu
+package transputer.plugins.fpu
 
 import spinal.core._
 import spinal.lib._

--- a/src/main/scala/transputer/plugins/fpu/DivRoot.scala
+++ b/src/main/scala/transputer/plugins/fpu/DivRoot.scala
@@ -1,8 +1,8 @@
-package t800.plugins.fpu
+package transputer.plugins.fpu
 
 import spinal.core._
 import spinal.lib._
-import t800.plugins.fpu.Utils._
+import transputer.plugins.fpu.Utils._
 
 /** Minimal IEEE‑754 divider/square‑root unit used by the unit tests. The design performs the
   * operations in a single cycle using integer math which is sufficient for the small set of

--- a/src/main/scala/transputer/plugins/fpu/FpuPlugin.scala
+++ b/src/main/scala/transputer/plugins/fpu/FpuPlugin.scala
@@ -1,4 +1,4 @@
-package t800.plugins.fpu
+package transputer.plugins.fpu
 
 import spinal.core._
 import spinal.lib._
@@ -13,12 +13,12 @@ import spinal.lib.bus.bmb.{
   BmbUnburstify,
   BmbDownSizerBridge
 }
-import t800.{Global, T800, Opcode}
-import t800.plugins.SystemBusSrv
-import t800.plugins.registers.RegfileSrv
-import t800.plugins.registers.RegName
-import t800.plugins.pipeline.{PipelineSrv, PipelineStageSrv}
-import t800.plugins.fpu.Utils._
+import transputer.{Global, Transputer, Opcode}
+import transputer.plugins.SystemBusSrv
+import transputer.plugins.registers.RegfileSrv
+import transputer.plugins.registers.RegName
+import transputer.plugins.pipeline.{PipelineSrv, PipelineStageSrv}
+import transputer.plugins.fpu.Utils._
 
 class FpuPlugin extends FiberPlugin with PipelineSrv {
   val version = "FpuPlugin v0.3"
@@ -78,7 +78,7 @@ class FpuPlugin extends FiberPlugin with PipelineSrv {
     val memBmb = Bmb(memParam)
     val unburstify = BmbUnburstify(memParam)
     val downSizer = BmbDownSizerBridge(
-      inputParameter = T800.systemBusParam,
+      inputParameter = Transputer.systemBusParam,
       outputParameter = memParam
     )
     memBmb >> unburstify.io.input

--- a/src/main/scala/transputer/plugins/fpu/Multiplier.scala
+++ b/src/main/scala/transputer/plugins/fpu/Multiplier.scala
@@ -1,8 +1,8 @@
-package t800.plugins.fpu
+package transputer.plugins.fpu
 
 import spinal.core._
 import spinal.lib._
-import t800.plugins.fpu.Utils._
+import transputer.plugins.fpu.Utils._
 
 class FpuMultiplier extends Area {
   val io = new Bundle {

--- a/src/main/scala/transputer/plugins/fpu/Opcodes.scala
+++ b/src/main/scala/transputer/plugins/fpu/Opcodes.scala
@@ -1,8 +1,8 @@
-package t800.plugins.fpu
+package transputer.plugins.fpu
 
 import spinal.core._
 import spinal.lib._
-import t800.Opcode
+import transputer.Opcode
 
 case class FpCmd() extends Bundle {
   val op = FpOp()
@@ -61,7 +61,7 @@ object FpOp extends SpinalEnum(binarySequential) {
 
   val NONE = newElement()
 
-  // Mapping from raw opcodes to FpOp value. The full T800 implementation uses
+  // Mapping from raw opcodes to FpOp value. The full Transputer implementation uses
   // a large MuxCase statement which pulls in additional dependencies. For the
   // minimal build we only require the enumeration definitions, so this helper is
   // implemented here using a simple decoder. Unknown opcodes map to [[FpOp.NONE]].

--- a/src/main/scala/transputer/plugins/fpu/RangeReducer.scala
+++ b/src/main/scala/transputer/plugins/fpu/RangeReducer.scala
@@ -1,8 +1,8 @@
-package t800.plugins.fpu
+package transputer.plugins.fpu
 
 import spinal.core._
 import spinal.lib._
-import t800.plugins.fpu.Utils._
+import transputer.plugins.fpu.Utils._
 
 class FpuRangeReducer extends Component {
   val io = new Bundle {

--- a/src/main/scala/transputer/plugins/fpu/Service.scala
+++ b/src/main/scala/transputer/plugins/fpu/Service.scala
@@ -1,13 +1,13 @@
-package t800.plugins.fpu
+package transputer.plugins.fpu
 
 import spinal.core._
 import spinal.lib._
 import spinal.lib.misc.pipeline._
-import t800.Global
+import transputer.Global
 
 // Forward simple command and operation definitions from `Opcodes.scala`.
 // This avoids duplicate type names when both files are included in the build.
-import t800.plugins.fpu.{FpCmd, FpOp}
+import transputer.plugins.fpu.{FpCmd, FpOp}
 
 trait FpuSrv {
   def pipe: Flow[FpCmd]

--- a/src/main/scala/transputer/plugins/fpu/Utils.scala
+++ b/src/main/scala/transputer/plugins/fpu/Utils.scala
@@ -1,4 +1,4 @@
-package t800.plugins.fpu
+package transputer.plugins.fpu
 
 import spinal.core._
 import spinal.lib._

--- a/src/main/scala/transputer/plugins/fpu/VCU.scala
+++ b/src/main/scala/transputer/plugins/fpu/VCU.scala
@@ -1,8 +1,8 @@
-package t800.plugins.fpu
+package transputer.plugins.fpu
 
 import spinal.core._
 import spinal.lib._
-import t800.Opcode
+import transputer.Opcode
 
 class FpuVCU extends Component {
   val io = new Bundle {

--- a/src/main/scala/transputer/plugins/grouper/InstrGrouperPlugin.scala
+++ b/src/main/scala/transputer/plugins/grouper/InstrGrouperPlugin.scala
@@ -1,15 +1,15 @@
-package t800.plugins.grouper
+package transputer.plugins.grouper
 
 import spinal.core._
 import spinal.lib._
 import spinal.lib.misc.plugin.{PluginHost, FiberPlugin, Plugin}
 import spinal.lib.misc.pipeline._
 import spinal.core.fiber.Retainer
-import t800.{Global, Opcode}
-import t800.plugins.registers.RegfileSrv
-import t800.plugins.Fetch
-import t800.plugins.registers.RegName
-import t800.plugins.pipeline.{PipelineSrv, PipelineStageSrv}
+import transputer.{Global, Opcode}
+import transputer.plugins.registers.RegfileSrv
+import transputer.plugins.Fetch
+import transputer.plugins.registers.RegName
+import transputer.plugins.pipeline.{PipelineSrv, PipelineStageSrv}
 
 /** Assembles groups of up to eight instructions from the fetch stage, respecting pipeline stage
   * constraints and dependencies, for delivery to the PrimaryInstrPlugin (decode) stage.

--- a/src/main/scala/transputer/plugins/grouper/Service.scala
+++ b/src/main/scala/transputer/plugins/grouper/Service.scala
@@ -1,8 +1,8 @@
-package t800.plugins.grouper
+package transputer.plugins.grouper
 
 import spinal.core._
 import spinal.lib._
-import t800.Global
+import transputer.Global
 
 case class GroupedInstructions() extends Bundle {
   val instructions = Vec(Bits(Global.OPCODE_BITS bits), 8)

--- a/src/main/scala/transputer/plugins/mmu/MemoryManagementPlugin.scala
+++ b/src/main/scala/transputer/plugins/mmu/MemoryManagementPlugin.scala
@@ -1,18 +1,18 @@
-package t800.plugins.mmu
+package transputer.plugins.mmu
 
 import spinal.core._
 import spinal.core.fiber._
 import spinal.lib._
 import spinal.lib.misc.plugin._
 import spinal.lib.misc.pipeline._
-import t800.plugins.pmi.PmiPlugin
-import t800.plugins.cache.{MainCachePlugin, WorkspaceCachePlugin, CacheAccessSrv}
-import t800.plugins.schedule.SchedulerPlugin
-import t800.plugins.{TrapHandlerSrv, ConfigAccessSrv, AddressTranslationSrv, Fetch}
-import t800.plugins.registers.RegfileSrv
-import t800.plugins.pipeline.PipelineStageSrv
-import t800.plugins.registers.RegName
-import t800.{Global, T800}
+import transputer.plugins.pmi.PmiPlugin
+import transputer.plugins.cache.{MainCachePlugin, WorkspaceCachePlugin, CacheAccessSrv}
+import transputer.plugins.schedule.SchedulerPlugin
+import transputer.plugins.{TrapHandlerSrv, ConfigAccessSrv, AddressTranslationSrv, Fetch}
+import transputer.plugins.registers.RegfileSrv
+import transputer.plugins.pipeline.PipelineStageSrv
+import transputer.plugins.registers.RegName
+import transputer.{Global, Transputer}
 
 class MemoryManagementPlugin extends FiberPlugin {
   val version = "MemoryManagementPlugin v1.5"

--- a/src/main/scala/transputer/plugins/mmu/Service.scala
+++ b/src/main/scala/transputer/plugins/mmu/Service.scala
@@ -1,8 +1,8 @@
-package t800.plugins.mmu
+package transputer.plugins.mmu
 
 import spinal.core._
 import spinal.lib._
-import t800.Global
+import transputer.Global
 
 case class TrapHandlerSrv() extends Bundle {
   val trapAddr = Bits(Global.ADDR_BITS bits)

--- a/src/main/scala/transputer/plugins/pipeline/PipelineBuilderPlugin.scala
+++ b/src/main/scala/transputer/plugins/pipeline/PipelineBuilderPlugin.scala
@@ -1,11 +1,11 @@
-package t800.plugins.pipeline
+package transputer.plugins.pipeline
 
 import spinal.core._
 import spinal.lib.misc.plugin.{PluginHost, FiberPlugin}
 import spinal.lib.misc.pipeline._
 import spinal.core.fiber.Retainer
-import t800.{Global, T800}
-import t800.plugins.pipeline.PipelineStageSrv
+import transputer.{Global, Transputer}
+import transputer.plugins.pipeline.PipelineStageSrv
 
 class PipelineBuilderPlugin extends FiberPlugin {
   val version = "PipelineBuilderPlugin v0.5"

--- a/src/main/scala/transputer/plugins/pipeline/PipelinePlugin.scala
+++ b/src/main/scala/transputer/plugins/pipeline/PipelinePlugin.scala
@@ -1,11 +1,11 @@
-package t800.plugins.pipeline
+package transputer.plugins.pipeline
 
 import spinal.core._
 import spinal.lib.misc.pipeline._
 import spinal.core.fiber.Retainer
 import spinal.lib.misc.plugin._
-import t800.Global
-import t800.plugins.pipeline.PipelineStageSrv
+import transputer.Global
+import transputer.plugins.pipeline.PipelineStageSrv
 
 /** Defines the global CPU pipeline structure and exposes stage handles. */
 class PipelinePlugin extends FiberPlugin {

--- a/src/main/scala/transputer/plugins/pipeline/Service.scala
+++ b/src/main/scala/transputer/plugins/pipeline/Service.scala
@@ -1,4 +1,4 @@
-package t800.plugins.pipeline
+package transputer.plugins.pipeline
 
 import spinal.core._
 import spinal.lib._

--- a/src/main/scala/transputer/plugins/pmi/PmiPlugin.scala
+++ b/src/main/scala/transputer/plugins/pmi/PmiPlugin.scala
@@ -1,7 +1,7 @@
-package t800.plugins.pmi
+package transputer.plugins.pmi
 
-import t800.plugins._
-import t800.plugins.cache.{MainCachePlugin, WorkspaceCachePlugin}
+import transputer.plugins._
+import transputer.plugins.cache.{MainCachePlugin, WorkspaceCachePlugin}
 
 import spinal.core._
 import spinal.core.fiber._

--- a/src/main/scala/transputer/plugins/pmi/Service.scala
+++ b/src/main/scala/transputer/plugins/pmi/Service.scala
@@ -1,4 +1,4 @@
-package t800.plugins.pmi
+package transputer.plugins.pmi
 
 import spinal.core._
 

--- a/src/main/scala/transputer/plugins/registers/RegFilePlugin.scala
+++ b/src/main/scala/transputer/plugins/registers/RegFilePlugin.scala
@@ -1,9 +1,9 @@
-package t800.plugins.registers
+package transputer.plugins.registers
 
 import spinal.core._
 import spinal.lib._
 import spinal.lib.misc.plugin.FiberPlugin
-import t800.Global
+import transputer.Global
 
 /** Minimal stub register file for unit tests. */
 class RegFilePlugin extends FiberPlugin with RegfileSrv {

--- a/src/main/scala/transputer/plugins/registers/Service.scala
+++ b/src/main/scala/transputer/plugins/registers/Service.scala
@@ -1,8 +1,8 @@
-package t800.plugins.registers
+package transputer.plugins.registers
 
 import spinal.core._
 import spinal.lib._
-import t800.Global
+import transputer.Global
 
 trait RegfileSpec {
   def width: Int

--- a/src/main/scala/transputer/plugins/schedule/SchedulerPlugin.scala
+++ b/src/main/scala/transputer/plugins/schedule/SchedulerPlugin.scala
@@ -1,4 +1,4 @@
-package t800.plugins.schedule
+package transputer.plugins.schedule
 
 import spinal.core._
 import spinal.lib._
@@ -6,7 +6,7 @@ import spinal.lib.misc.pipeline._
 import spinal.core.fiber.Retainer
 import spinal.core.sim._
 import spinal.lib.misc.plugin._
-import t800.Global
+import transputer.Global
 
 /** Minimal round-robin scheduler with high/low priority queues. */
 class SchedulerPlugin extends FiberPlugin {

--- a/src/main/scala/transputer/plugins/schedule/Service.scala
+++ b/src/main/scala/transputer/plugins/schedule/Service.scala
@@ -1,10 +1,10 @@
-package t800.plugins.schedule
+package transputer.plugins.schedule
 
 import spinal.core._
 import spinal.lib._
 
 case class SchedCmd() extends Bundle {
-  val ptr = UInt(t800.Global.ADDR_BITS bits)
+  val ptr = UInt(transputer.Global.ADDR_BITS bits)
   val high = Bool()
 }
 

--- a/src/main/scala/transputer/plugins/stack/Service.scala
+++ b/src/main/scala/transputer/plugins/stack/Service.scala
@@ -1,9 +1,9 @@
-package t800.plugins.stack
+package transputer.plugins.stack
 
 import spinal.core._
 import spinal.lib._
 
-/** Service interface for workspace memory access in the T800 pipeline. */
+/** Service interface for workspace memory access in the Transputer pipeline. */
 trait StackSrv {
   def read(offset: SInt): UInt // Read from workspace at WdescReg + offset
   def write(offset: SInt, data: UInt): Unit // Write to workspace at WdescReg + offset

--- a/src/main/scala/transputer/plugins/stack/StackPlugin.scala
+++ b/src/main/scala/transputer/plugins/stack/StackPlugin.scala
@@ -1,16 +1,16 @@
-package t800.plugins.stack
+package transputer.plugins.stack
 
 import spinal.core._
 import spinal.core.fiber.Retainer
 import spinal.lib._
 import spinal.lib.misc.plugin.{FiberPlugin, Plugin}
 import spinal.lib.bus.bmb.{Bmb, BmbParameter, BmbAccessParameter, BmbDownSizerBridge, BmbUnburstify}
-import t800.{Global, T800}
-import t800.plugins.SystemBusSrv
-import t800.plugins.registers.RegfileSrv
-import t800.plugins.registers.RegName
+import transputer.{Global, Transputer}
+import transputer.plugins.SystemBusSrv
+import transputer.plugins.registers.RegfileSrv
+import transputer.plugins.registers.RegName
 
-/** Manages workspace memory access for local variable operations (LDL, STL, CALL) in the T800
+/** Manages workspace memory access for local variable operations (LDL, STL, CALL) in the Transputer
   * pipeline.
   */
 
@@ -55,7 +55,7 @@ class StackPlugin extends FiberPlugin {
     if (workspaceCache != null) {
       val unburstify = BmbUnburstify(memParam)
       val downSizer = BmbDownSizerBridge(
-        inputParameter = T800.systemBusParam,
+        inputParameter = Transputer.systemBusParam,
         outputParameter = memParam
       )
       memBmb >> unburstify.io.input

--- a/src/main/scala/transputer/plugins/timers/Service.scala
+++ b/src/main/scala/transputer/plugins/timers/Service.scala
@@ -1,4 +1,4 @@
-package t800.plugins.timers
+package transputer.plugins.timers
 
 import spinal.core._
 

--- a/src/main/scala/transputer/plugins/timers/TimerPlugin.scala
+++ b/src/main/scala/transputer/plugins/timers/TimerPlugin.scala
@@ -1,12 +1,12 @@
-package t800.plugins.timers
+package transputer.plugins.timers
 
 import spinal.core._
 import spinal.lib._
 import spinal.core.sim._
 import spinal.core.fiber.Retainer
 import spinal.lib.misc.plugin._
-import t800.Global
-import t800.plugins.timers._
+import transputer.Global
+import transputer.plugins.timers._
 
 /** Simple high/low priority timers. High increments every cycle; low every 64 cycles. */
 class TimerPlugin extends FiberPlugin {

--- a/src/main/scala/transputer/plugins/transputer/Service.scala
+++ b/src/main/scala/transputer/plugins/transputer/Service.scala
@@ -1,4 +1,4 @@
-package t800.plugins.transputer
+package transputer.plugins.transputer
 
 /** Placeholder for Transputer-specific services. */
 trait TransputerSrv

--- a/src/main/scala/transputer/plugins/transputer/TransputerPlugin.scala
+++ b/src/main/scala/transputer/plugins/transputer/TransputerPlugin.scala
@@ -1,12 +1,12 @@
-package t800.plugins.transputer
+package transputer.plugins.transputer
 
 import spinal.core._
 import spinal.lib.misc.database.{Database, Element}
 import spinal.lib.misc.plugin.FiberPlugin
-import t800.Global
+import transputer.Global
 
-/** Centralized configuration plugin for T800, setting T9000-specific parameters in the Database.
-  * Reads variant parameters from Database if set, else uses defaults.
+/** Centralized configuration plugin for Transputer, setting T9000-specific parameters in the
+  * Database. Reads variant parameters from Database if set, else uses defaults.
   */
 class TransputerPlugin(
   var wordBits: Int = Global.WordBits,

--- a/src/main/scala/transputer/plugins/vcp/Service.scala
+++ b/src/main/scala/transputer/plugins/vcp/Service.scala
@@ -1,7 +1,7 @@
-package t800.plugins.vcp
+package transputer.plugins.vcp
 
 import spinal.core._
-import t800.plugins.ChannelSrv
+import transputer.plugins.ChannelSrv
 
 trait VcpSrv extends ChannelSrv {
   def scheduleInput(channel: Int): Unit

--- a/src/main/scala/transputer/plugins/vcp/VcpPlugin.scala
+++ b/src/main/scala/transputer/plugins/vcp/VcpPlugin.scala
@@ -1,7 +1,7 @@
-package t800.plugins.vcp
+package transputer.plugins.vcp
 
-import t800.plugins._
-import t800.plugins.schedule.SchedulerPlugin
+import transputer.plugins._
+import transputer.plugins.schedule.SchedulerPlugin
 
 import spinal.core._
 import spinal.core.fiber._
@@ -16,7 +16,7 @@ import spinal.lib.bus.bmb.{
   BmbQueue
 }
 import spinal.lib.com.spi.ddr.{SpiXdrMasterCtrl, SpiXdrParameter}
-import t800.Global
+import transputer.Global
 
 /** Plugin for T9000 Virtual Channel Processor (VCP) with four SpiXdrMasterCtrl links. */
 class VcpPlugin extends FiberPlugin {

--- a/src/test/scala/transputer/ChannelDmaSpec.scala
+++ b/src/test/scala/transputer/ChannelDmaSpec.scala
@@ -1,14 +1,14 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import spinal.lib._
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins._
+import transputer.plugins._
 import spinal.lib.misc.plugin.PluginHost
-import t800.plugins.schedule.SchedulerPlugin
-import t800.{DummyTimerPlugin, DummyFpuPlugin}
-import t800.plugins.grouper.GrouperPlugin
+import transputer.plugins.schedule.SchedulerPlugin
+import transputer.{DummyTimerPlugin, DummyFpuPlugin}
+import transputer.plugins.grouper.GrouperPlugin
 
 class ChannelDmaSpec extends AnyFunSuite {
   test("DMA opcode transfers bytes") {
@@ -32,7 +32,7 @@ class ChannelDmaSpec extends AnyFunSuite {
           new SchedulerPlugin,
           new PipelineBuilderPlugin
         )
-        PluginHost(host).on(T800(p))
+        PluginHost(host).on(Transputer(p))
       }
       .doSim { dut =>
         dut.clockDomain.forkStimulus(10)

--- a/src/test/scala/transputer/DataBaseElementSpec.scala
+++ b/src/test/scala/transputer/DataBaseElementSpec.scala
@@ -1,4 +1,4 @@
-package t800
+package transputer
 
 import org.scalatest.funsuite.AnyFunSuite
 import spinal.lib.misc.database.{Database, ElementLanda}

--- a/src/test/scala/transputer/DivRootSpec.scala
+++ b/src/test/scala/transputer/DivRootSpec.scala
@@ -1,9 +1,9 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins.fpu.FpuDivRoot
+import transputer.plugins.fpu.FpuDivRoot
 
 class DivRootDut extends Component {
   val io = new Bundle {

--- a/src/test/scala/transputer/FpOpcodeSpec.scala
+++ b/src/test/scala/transputer/FpOpcodeSpec.scala
@@ -1,9 +1,9 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins.fpu.FpOp
+import transputer.plugins.fpu.FpOp
 
 class FpDecodeDut extends Component {
   val io = new Bundle {

--- a/src/test/scala/transputer/FpuAdderSpec.scala
+++ b/src/test/scala/transputer/FpuAdderSpec.scala
@@ -1,11 +1,11 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import spinal.lib._
 import scala.math
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins.fpu.{FpuAdder, Adder}
+import transputer.plugins.fpu.{FpuAdder, Adder}
 
 class FpuAdderDut extends Component {
   val io = new Bundle {

--- a/src/test/scala/transputer/FpuBusySpec.scala
+++ b/src/test/scala/transputer/FpuBusySpec.scala
@@ -1,4 +1,4 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._

--- a/src/test/scala/transputer/FpuOpcodeSpec.scala
+++ b/src/test/scala/transputer/FpuOpcodeSpec.scala
@@ -1,11 +1,11 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
 import spinal.lib.misc.plugin.PluginHost
 import spinal.lib.misc.database.Database
-import t800.plugins.fpu._
+import transputer.plugins.fpu._
 
 /** Execute FPU opcodes using their raw byte encoding. */
 class FpuOpcodeDut extends Component {
@@ -20,8 +20,8 @@ class FpuOpcodeDut extends Component {
   }
 
   val host = new PluginHost
-  val plugins = T800.unitPlugins() ++ Seq(new DummyTrapPlugin, new FpuPlugin)
-  PluginHost(host).on(Database(T800.defaultDatabase()).on(T800(plugins)))
+  val plugins = Transputer.unitPlugins() ++ Seq(new DummyTrapPlugin, new FpuPlugin)
+  PluginHost(host).on(Database(Transputer.defaultDatabase()).on(Transputer(plugins)))
 
   val fpuSrv = host[FpuSrv]
   val ctrl = host[FpuControlSrv]

--- a/src/test/scala/transputer/FpuPluginSpec.scala
+++ b/src/test/scala/transputer/FpuPluginSpec.scala
@@ -1,11 +1,11 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
 import spinal.lib.misc.plugin.PluginHost
 import spinal.lib.misc.database.Database
-import t800.plugins.fpu._
+import transputer.plugins.fpu._
 
 /** Wrapper around [[FpuPlugin]] exposing a simple command interface. */
 class FpuDut extends Component {
@@ -21,8 +21,8 @@ class FpuDut extends Component {
 
   // Build minimal plugin stack with mock trap handler
   val host = new PluginHost
-  val plugins = T800.unitPlugins() ++ Seq(new DummyTrapPlugin, new FpuPlugin)
-  PluginHost(host).on(Database(T800.defaultDatabase()).on(T800(plugins)))
+  val plugins = Transputer.unitPlugins() ++ Seq(new DummyTrapPlugin, new FpuPlugin)
+  PluginHost(host).on(Database(Transputer.defaultDatabase()).on(Transputer(plugins)))
 
   val fpuSrv = host[FpuSrv]
   val ctrl = host[FpuControlSrv]

--- a/src/test/scala/transputer/FpuVCUSpec.scala
+++ b/src/test/scala/transputer/FpuVCUSpec.scala
@@ -1,9 +1,9 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins.fpu.FpuVCU
+import transputer.plugins.fpu.FpuVCU
 
 class VcuDut extends Component {
   val io = new Bundle {

--- a/src/test/scala/transputer/GlobalDatabaseSpec.scala
+++ b/src/test/scala/transputer/GlobalDatabaseSpec.scala
@@ -1,11 +1,11 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import spinal.lib.misc.database.Database
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins._
-import t800.plugins.timers.TimerPlugin
+import transputer.plugins._
+import transputer.plugins.timers.TimerPlugin
 import spinal.lib.misc.plugin.PluginHost
 
 class GlobalDatabaseSpec extends AnyFunSuite {
@@ -29,7 +29,7 @@ class GlobalDatabaseSpec extends AnyFunSuite {
         val host = new PluginHost
         val plugins = Seq(new TimerPlugin, new TimerProbePlugin)
         PluginHost(host).on {
-          Database(db).on(T800(plugins))
+          Database(db).on(Transputer(plugins))
         }
       }
       .doSim { dut =>

--- a/src/test/scala/transputer/GrouperPluginSpec.scala
+++ b/src/test/scala/transputer/GrouperPluginSpec.scala
@@ -1,10 +1,10 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins._
-import t800.plugins.grouper.GrouperPlugin
+import transputer.plugins._
+import transputer.plugins.grouper.GrouperPlugin
 import spinal.lib.misc.plugin.PluginHost
 
 class GrouperPluginSpec extends AnyFunSuite {
@@ -30,7 +30,7 @@ class GrouperPluginSpec extends AnyFunSuite {
           new GrouperPlugin,
           new PipelineBuilderPlugin
         )
-        PluginHost(host).on(T800(plugins))
+        PluginHost(host).on(Transputer(plugins))
       }
       .doSim { dut =>
         dut.clockDomain.forkStimulus(10)

--- a/src/test/scala/transputer/HelloWorldSim.scala
+++ b/src/test/scala/transputer/HelloWorldSim.scala
@@ -1,12 +1,12 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
-import t800.plugins._
+import transputer.plugins._
 import spinal.lib.misc.plugin.PluginHost
-import t800.plugins.schedule.SchedulerPlugin
-import t800.plugins.timers.TimerPlugin
-import t800.plugins.grouper.GrouperPlugin
+import transputer.plugins.schedule.SchedulerPlugin
+import transputer.plugins.timers.TimerPlugin
+import transputer.plugins.grouper.GrouperPlugin
 
 object HelloWorldSim {
 
@@ -31,7 +31,7 @@ object HelloWorldSim {
           new TimerPlugin,
           new PipelineBuilderPlugin
         )
-        PluginHost(host).on(T800(p))
+        PluginHost(host).on(Transputer(p))
       }
       .doSim { dut =>
         dut.clockDomain.forkStimulus(10)

--- a/src/test/scala/transputer/HelloWorldSpec.scala
+++ b/src/test/scala/transputer/HelloWorldSpec.scala
@@ -1,13 +1,13 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins._
+import transputer.plugins._
 import spinal.lib.misc.plugin.PluginHost
-import t800.plugins.schedule.SchedulerPlugin
-import t800.plugins.timers.TimerPlugin
-import t800.plugins.grouper.GrouperPlugin
+import transputer.plugins.schedule.SchedulerPlugin
+import transputer.plugins.timers.TimerPlugin
+import transputer.plugins.grouper.GrouperPlugin
 
 class HelloWorldSpec extends AnyFunSuite {
   ignore("ROM program prints hello world") {
@@ -27,7 +27,7 @@ class HelloWorldSpec extends AnyFunSuite {
           new TimerPlugin,
           new PipelineBuilderPlugin
         )
-        PluginHost(host).on(T800(plugins))
+        PluginHost(host).on(Transputer(plugins))
       }
       .doSim { dut =>
         dut.clockDomain.forkStimulus(10)

--- a/src/test/scala/transputer/InitTransputerSpec.scala
+++ b/src/test/scala/transputer/InitTransputerSpec.scala
@@ -1,12 +1,12 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import spinal.lib._
 import scala.math
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins.pipeline.PipelineSrv
-import t800.plugins.fpu.{FpuAdder, Adder}
+import transputer.plugins.pipeline.PipelineSrv
+import transputer.plugins.fpu.{FpuAdder, Adder}
 
 class AdderDutTiny extends Component {
   val io = new Bundle {
@@ -20,11 +20,11 @@ class AdderDutTiny extends Component {
   add.io.rsp.ready := True
 }
 
-/** Ensure minimal T800 configuration builds with basic pipeline. */
+/** Ensure minimal Transputer configuration builds with basic pipeline. */
 class InitTransputerSpec extends AnyFunSuite {
   test("TransputerPlugin sets default configuration") {
-    val db = T800.defaultDatabase()
-    val report = SpinalConfig().generateVerilog(new T800Unit(db))
+    val db = Transputer.defaultDatabase()
+    val report = SpinalConfig().generateVerilog(new TransputerUnit(db))
     assert(db(Global.WORD_BITS) == Global.WordBits)
     assert(db(Global.RAM_WORDS) == Global.RamWords)
   }

--- a/src/test/scala/transputer/LdnlpSpec.scala
+++ b/src/test/scala/transputer/LdnlpSpec.scala
@@ -1,4 +1,4 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._

--- a/src/test/scala/transputer/LongOpsSpec.scala
+++ b/src/test/scala/transputer/LongOpsSpec.scala
@@ -1,4 +1,4 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._

--- a/src/test/scala/transputer/Move2DSpec.scala
+++ b/src/test/scala/transputer/Move2DSpec.scala
@@ -1,12 +1,12 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins._
+import transputer.plugins._
 import spinal.lib.misc.plugin.PluginHost
-import t800.plugins.schedule.SchedulerPlugin
-import t800.plugins.grouper.GrouperPlugin
+import transputer.plugins.schedule.SchedulerPlugin
+import transputer.plugins.grouper.GrouperPlugin
 
 class Move2DSpec extends AnyFunSuite {
   test("MOVE2DALL transfers 2D bytes") {
@@ -34,7 +34,7 @@ class Move2DSpec extends AnyFunSuite {
           new SchedulerPlugin,
           new PipelineBuilderPlugin
         )
-        PluginHost(host).on(T800(p))
+        PluginHost(host).on(Transputer(p))
       }
       .doSim { dut =>
         dut.clockDomain.forkStimulus(10)

--- a/src/test/scala/transputer/OprAndSpec.scala
+++ b/src/test/scala/transputer/OprAndSpec.scala
@@ -1,4 +1,4 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._

--- a/src/test/scala/transputer/OprLdlSpec.scala
+++ b/src/test/scala/transputer/OprLdlSpec.scala
@@ -1,15 +1,15 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins._
+import transputer.plugins._
 import spinal.lib._
-import t800.plugins.schedule.SchedulerPlugin
+import transputer.plugins.schedule.SchedulerPlugin
 import spinal.lib.misc.plugin.PluginHost
 
-import t800.{DummyTimerPlugin, DummyFpuPlugin}
-import t800.plugins.grouper.GrouperPlugin
+import transputer.{DummyTimerPlugin, DummyFpuPlugin}
+import transputer.plugins.grouper.GrouperPlugin
 
 class OprLdlSpec extends AnyFunSuite {
   test("LDL loads from workspace") {
@@ -34,7 +34,7 @@ class OprLdlSpec extends AnyFunSuite {
           new SchedulerPlugin,
           new PipelineBuilderPlugin
         )
-        PluginHost(host).on(T800(p))
+        PluginHost(host).on(Transputer(p))
       }
       .doSim { dut =>
         dut.clockDomain.forkStimulus(10)

--- a/src/test/scala/transputer/OprRevSpec.scala
+++ b/src/test/scala/transputer/OprRevSpec.scala
@@ -1,4 +1,4 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._

--- a/src/test/scala/transputer/OprShlSpec.scala
+++ b/src/test/scala/transputer/OprShlSpec.scala
@@ -1,4 +1,4 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._

--- a/src/test/scala/transputer/OprShrSpec.scala
+++ b/src/test/scala/transputer/OprShrSpec.scala
@@ -1,4 +1,4 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._

--- a/src/test/scala/transputer/OprStlSpec.scala
+++ b/src/test/scala/transputer/OprStlSpec.scala
@@ -1,14 +1,14 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins._
+import transputer.plugins._
 import spinal.lib._
-import t800.plugins.schedule.SchedulerPlugin
+import transputer.plugins.schedule.SchedulerPlugin
 import spinal.lib.misc.plugin.PluginHost
-import t800.{DummyTimerPlugin, DummyFpuPlugin}
-import t800.plugins.grouper.GrouperPlugin
+import transputer.{DummyTimerPlugin, DummyFpuPlugin}
+import transputer.plugins.grouper.GrouperPlugin
 
 class OprStlSpec extends AnyFunSuite {
   test("STL stores A and updates stack") {
@@ -33,7 +33,7 @@ class OprStlSpec extends AnyFunSuite {
           new SchedulerPlugin,
           new PipelineBuilderPlugin
         )
-        PluginHost(host).on(T800(p))
+        PluginHost(host).on(Transputer(p))
       }
       .doSim { dut =>
         dut.clockDomain.forkStimulus(10)

--- a/src/test/scala/transputer/OprSubSpec.scala
+++ b/src/test/scala/transputer/OprSubSpec.scala
@@ -1,4 +1,4 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._

--- a/src/test/scala/transputer/OprXorSpec.scala
+++ b/src/test/scala/transputer/OprXorSpec.scala
@@ -1,4 +1,4 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._

--- a/src/test/scala/transputer/PrefixSpec.scala
+++ b/src/test/scala/transputer/PrefixSpec.scala
@@ -1,13 +1,13 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins._
+import transputer.plugins._
 import spinal.lib.misc.plugin.PluginHost
-import t800.plugins.schedule.SchedulerPlugin
-import t800.{DummyTimerPlugin, DummyFpuPlugin}
-import t800.plugins.grouper.GrouperPlugin
+import transputer.plugins.schedule.SchedulerPlugin
+import transputer.{DummyTimerPlugin, DummyFpuPlugin}
+import transputer.plugins.grouper.GrouperPlugin
 
 class PrefixSpec extends AnyFunSuite {
   test("PFIX/NFIX build literals") {
@@ -31,7 +31,7 @@ class PrefixSpec extends AnyFunSuite {
           new SchedulerPlugin,
           new PipelineBuilderPlugin
         )
-        PluginHost(host).on(T800(p))
+        PluginHost(host).on(Transputer(p))
       }
       .doSim { dut =>
         dut.clockDomain.forkStimulus(10)

--- a/src/test/scala/transputer/RangeReducerSpec.scala
+++ b/src/test/scala/transputer/RangeReducerSpec.scala
@@ -1,9 +1,9 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins.fpu._
+import transputer.plugins.fpu._
 
 class RangeReducerDut extends Component {
   val io = new Bundle {

--- a/src/test/scala/transputer/Real32ToReal64Spec.scala
+++ b/src/test/scala/transputer/Real32ToReal64Spec.scala
@@ -1,4 +1,4 @@
-package t800
+package transputer
 
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/src/test/scala/transputer/RunpStoppSpec.scala
+++ b/src/test/scala/transputer/RunpStoppSpec.scala
@@ -1,13 +1,13 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
 import spinal.lib.misc.plugin.PluginHost
-import t800.plugins._
-import t800.{DummyTimerPlugin, DummyFpuPlugin}
-import t800.plugins.schedule.{SchedulerPlugin, SchedSrv}
-import t800.plugins.grouper.GrouperPlugin
+import transputer.plugins._
+import transputer.{DummyTimerPlugin, DummyFpuPlugin}
+import transputer.plugins.schedule.{SchedulerPlugin, SchedSrv}
+import transputer.plugins.grouper.GrouperPlugin
 
 class RunpStoppSpec extends AnyFunSuite {
   test("RUNP enqueues A and STOPP enqueues WPtr") {
@@ -32,7 +32,7 @@ class RunpStoppSpec extends AnyFunSuite {
           new SchedulerPlugin,
           new PipelineBuilderPlugin
         )
-        PluginHost(host).on(T800(plugins))
+        PluginHost(host).on(Transputer(plugins))
       }
       .doSim { dut =>
         dut.clockDomain.forkStimulus(10)

--- a/src/test/scala/transputer/SchedulerSaveSpec.scala
+++ b/src/test/scala/transputer/SchedulerSaveSpec.scala
@@ -1,13 +1,13 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
 import spinal.lib.misc.plugin.PluginHost
-import t800.plugins._
-import t800.{DummyTimerPlugin, DummyFpuPlugin}
-import t800.plugins.schedule.{SchedulerPlugin, SchedSrv}
-import t800.plugins.grouper.GrouperPlugin
+import transputer.plugins._
+import transputer.{DummyTimerPlugin, DummyFpuPlugin}
+import transputer.plugins.schedule.{SchedulerPlugin, SchedSrv}
+import transputer.plugins.grouper.GrouperPlugin
 
 class SchedulerSaveSpec extends AnyFunSuite {
   test("LEND re-enqueues current workspace") {
@@ -31,7 +31,7 @@ class SchedulerSaveSpec extends AnyFunSuite {
           new SchedulerPlugin,
           new PipelineBuilderPlugin
         )
-        PluginHost(host).on(T800(plugins))
+        PluginHost(host).on(Transputer(plugins))
       }
       .doSim { dut =>
         dut.clockDomain.forkStimulus(10)

--- a/src/test/scala/transputer/T800CoreSim.scala
+++ b/src/test/scala/transputer/T800CoreSim.scala
@@ -1,11 +1,11 @@
-package t800
+package transputer
 
 import spinal.core.sim._
 import spinal.core._
 
-object T800CoreSim {
+object TransputerCoreSim {
   def main(args: Array[String]): Unit = {
-    SimConfig.withWave.compile(new T800Core).doSim { dut =>
+    SimConfig.withWave.compile(new TransputerCore).doSim { dut =>
       dut.clockDomain.forkStimulus(10)
       for (_ <- 0 until 150) { dut.clockDomain.waitSampling() }
     }

--- a/src/test/scala/transputer/TestPlugins.scala
+++ b/src/test/scala/transputer/TestPlugins.scala
@@ -1,10 +1,10 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.lib._
 import spinal.lib.misc.plugin.FiberPlugin
-import t800.plugins._
-import t800.plugins.fpu._
+import transputer.plugins._
+import transputer.plugins.fpu._
 
 // Minimal timer service used by DummyTimerPlugin
 trait TimerSrv {

--- a/src/test/scala/transputer/TimerEnableSpec.scala
+++ b/src/test/scala/transputer/TimerEnableSpec.scala
@@ -1,11 +1,11 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
-import t800.plugins._
-import t800.plugins.timers.TimerSrv
-import t800.Global
+import transputer.plugins._
+import transputer.plugins.timers.TimerSrv
+import transputer.Global
 import spinal.lib.misc.plugin.{PluginHost, FiberPlugin, Plugin}
 
 trait TimerProbeSrv { def hi: UInt; def lo: UInt }
@@ -34,7 +34,7 @@ class TimerEnableSpec extends AnyFunSuite {
       .compile {
         val host = new PluginHost
         val plugins = Seq(new TimerPlugin, new TimerProbePlugin)
-        PluginHost(host).on(T800(plugins))
+        PluginHost(host).on(Transputer(plugins))
       }
       .doSim { dut =>
         dut.clockDomain.forkStimulus(10)

--- a/src/test/scala/transputer/TinAltwtSpec.scala
+++ b/src/test/scala/transputer/TinAltwtSpec.scala
@@ -1,14 +1,14 @@
-package t800
+package transputer
 
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
 import spinal.lib.misc.plugin.PluginHost
-import t800.plugins._
-import t800.plugins.timers.TimerPlugin
-import t800.plugins.grouper.GrouperPlugin
+import transputer.plugins._
+import transputer.plugins.timers.TimerPlugin
+import transputer.plugins.grouper.GrouperPlugin
 
-import t800.plugins.schedule.SchedulerPlugin
+import transputer.plugins.schedule.SchedulerPlugin
 class TinAltwtSpec extends AnyFunSuite {
   def buildRom(opcodes: Seq[Int]): Seq[BigInt] = {
     val bytes = opcodes.map(_.toByte)
@@ -42,7 +42,7 @@ class TinAltwtSpec extends AnyFunSuite {
           new TimerPlugin,
           new PipelineBuilderPlugin
         )
-        PluginHost(host).on(T800(plugins))
+        PluginHost(host).on(Transputer(plugins))
       }
       .doSim { dut =>
         dut.clockDomain.forkStimulus(10)


### PR DESCRIPTION
### What & Why
- moved old `t800` packages to `transputer`
- updated imports and class references from `T800` to `Transputer`

### Validation
- [x] sbt scalafmtAll
- [ ] sbt test *(fails: compile errors)*
- [ ] sbt "runMain Generate.DefaultBoard" *(fails: compile errors)*


------
https://chatgpt.com/codex/tasks/task_e_68518bfe4a74832595c40231e7a5a4fb