### PR TITLE
Rename register file spec

### DIFF
--- a/src/main/scala/transputer/plugins/registers/RegFilePlugin.scala
+++ b/src/main/scala/transputer/plugins/registers/RegFilePlugin.scala
@@ -12,7 +12,7 @@ class RegFilePlugin extends FiberPlugin with RegfileSrv {
   override def writeLatency = 1
   override def readLatency = 1
   override def getPhysicalDepth = 1
-  override def rfSpec = T9000RegFileSpec()
+  override def rfSpec = TransputerRegFileSpec()
 
   override def read(reg: RegName.C, processId: UInt, shadow: Boolean): Bits =
     B(0, rfSpec.width bits)

--- a/src/main/scala/transputer/plugins/registers/Service.scala
+++ b/src/main/scala/transputer/plugins/registers/Service.scala
@@ -11,11 +11,11 @@ trait RegfileSpec {
   def getName(): String
 }
 
-case class T9000RegFileSpec() extends RegfileSpec {
+case class TransputerRegFileSpec() extends RegfileSpec {
   override def width = 64 // Max width for FP registers
   override def sizeArch = RegName.elements.size // ~35 registers
   override def initialValue = B(0, 64 bits)
-  override def getName() = "T9000RegFile"
+  override def getName() = "TransputerRegFile"
 }
 
 object RegName extends SpinalEnum {
@@ -83,7 +83,7 @@ case class RegFileWrite(rfpp: RegFilePortParam, withReady: Boolean)
 }
 
 trait RegfileSrv {
-  def rfSpec: T9000RegFileSpec
+  def rfSpec: TransputerRegFileSpec
   def getPhysicalDepth: Int
   def writeLatency: Int
   def readLatency: Int


### PR DESCRIPTION
### What & Why
- Renamed `T9000RegFileSpec` to `TransputerRegFileSpec`
- Updated service trait and plugin override

### Validation
- [x] sbt scalafmtAll
- [ ] sbt test *(failed: 100 errors while compiling)*
- [ ] sbt "runMain transputer.Generate" *(failed: 100 errors while compiling)*


------
https://chatgpt.com/codex/tasks/task_e_6851968b50c08325b31d3129a3a2cf4d