### PR TITLE
Update plugin path docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ pipeline consistent:
    (Fetch, Decode, Execute, Memory, Writeback). Prefix with the subsystem name
    if it spans multiple stages.
 4. **Avoid overlap** – reuse existing services and keep names unique.
-5. **SpinalHDL conventions** – define services in `t800.plugins.<subsystem>`
-   packages and use camelCase for methods.
+5. **SpinalHDL conventions** – define services in `transputer.plugins.<subsystem>`
+    packages and use camelCase for methods.
 
 ---
 

--- a/src/main/scala/transputer/Generate.scala
+++ b/src/main/scala/transputer/Generate.scala
@@ -13,12 +13,20 @@ object Generate {
       import builder._
       OParser.sequence(
         programName("transputerGenerate"),
-        opt[Int]("word-width").action((x, c) => c.copy(wordWidth = x)).text("Width of words in bits"),
-        opt[Int]("link-count").action((x, c) => c.copy(linkCount = x)).text("Number of link channels"),
+        opt[Int]("word-width")
+          .action((x, c) => c.copy(wordWidth = x))
+          .text("Width of words in bits"),
+        opt[Int]("link-count")
+          .action((x, c) => c.copy(linkCount = x))
+          .text("Number of link channels"),
         opt[Boolean]("fpu").action((x, c) => c.copy(enableFpu = x)).text("Enable FPU"),
-        opt[Int]("fpu-precision").action((x, c) => c.copy(fpuPrecision = x)).text("FPU precision in bits (32/64)"),
+        opt[Int]("fpu-precision")
+          .action((x, c) => c.copy(fpuPrecision = x))
+          .text("FPU precision in bits (32/64)"),
         opt[Int]("cache-size").action((x, c) => c.copy(cacheSize = x)).text("Cache size in bytes"),
-        opt[Unit]("report-model").action((_, c) => c.copy(reportModel = true)).text("Print pipeline model and instruction details post-generation"),
+        opt[Unit]("report-model")
+          .action((_, c) => c.copy(reportModel = true))
+          .text("Print pipeline model and instruction details post-generation"),
         help("help").text("Display this help message")
       )
     }


### PR DESCRIPTION
### What & Why
- update README service naming guidance
- scalafmt cleanup on Generate.scala

### Validation
- `sbt scalafmtAll`
- `sbt test` *(fails: value addrB is not a member)*
- `sbt "runMain transputer.Generate"` *(fails with same compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_685197a559848325a09d3794f69a5252