### PR TITLE
Fix plugin imports

### DIFF
--- a/src/main/scala/transputer/Transputer.scala
+++ b/src/main/scala/transputer/Transputer.scala
@@ -6,8 +6,8 @@ import spinal.lib.misc.database.Database
 import spinal.lib.misc.plugin.{PluginHost, FiberPlugin, Hostable}
 import spinal.lib.bus.bmb.{Bmb, BmbParameter}
 import transputer.plugins.transputer.TransputerPlugin
-import transputer.pipeline.{PipelinePlugin, PipelineBuilderPlugin}
-import transputer.registers.RegFilePlugin
+import transputer.plugins.pipeline.{PipelinePlugin, PipelineBuilderPlugin}
+import transputer.plugins.registers.RegFilePlugin
 import transputer.SystemBusSrv
 
 object Transputer {


### PR DESCRIPTION
### What & Why
- fixed imports to use plugins subpackages

### Validation
- [x] sbt scalafmtAll
- [ ] sbt test *(failed: Compilation failed)*
- [ ] sbt "runMain transputer.Generate" *(failed: Compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851aeba410c8325a00501b6be6f3f9c