### PR TITLE
Add Bmb import to cache service

### DIFF
--- a/src/main/scala/transputer/plugins/cache/Service.scala
+++ b/src/main/scala/transputer/plugins/cache/Service.scala
@@ -2,6 +2,7 @@ package transputer.plugins.cache
 
 import spinal.core._
 import spinal.lib._
+import spinal.lib.bus.bmb.Bmb
 import transputer.Global
 
 case class CacheReq() extends Bundle {


### PR DESCRIPTION
### What & Why
- Added Bmb import for cache service to expose BMB interface

### Validation
- [x] sbt scalafmtAll
- [ ] sbt test
- [ ] sbt "runMain transputer.Generate"


------
https://chatgpt.com/codex/tasks/task_e_6851aee679e0832589c2266cfc9182ea