### PR TITLE
Fix Global import paths

### DIFF
--- a/src/main/scala/transputer/plugins/cache/MainCachePlugin.scala
+++ b/src/main/scala/transputer/plugins/cache/MainCachePlugin.scala
@@ -18,7 +18,8 @@ import spinal.lib.bus.bmb.{
 import transputer.plugins.pmi.PmiPlugin
 import transputer.plugins.{AddressTranslationSrv, WorkspaceCacheSrv, SystemBusSrv, Fetch}
 import transputer.plugins.pipeline.PipelineStageSrv
-import transputer.{Global, Transputer}
+import transputer.Global
+import transputer.Transputer
 
 class MainCachePlugin extends FiberPlugin {
   val version = "MainCachePlugin v1.7"

--- a/src/main/scala/transputer/plugins/decode/PrimaryInstrPlugin.scala
+++ b/src/main/scala/transputer/plugins/decode/PrimaryInstrPlugin.scala
@@ -6,7 +6,8 @@ import spinal.lib.misc.pipeline._
 import spinal.lib.misc.plugin._
 import spinal.core.fiber.Retainer
 import spinal.lib.bus.bmb.{Bmb, BmbParameter, BmbAccessParameter, BmbDownSizerBridge, BmbUnburstify}
-import transputer.{Global, Opcode, Transputer}
+import transputer.Global
+import transputer.{Opcode, Transputer}
 import transputer.plugins.registers.RegfileSrv
 import transputer.plugins.Fetch
 import transputer.plugins.grouper.GroupedInstrSrv

--- a/src/main/scala/transputer/plugins/execute/SecondaryInstrPlugin.scala
+++ b/src/main/scala/transputer/plugins/execute/SecondaryInstrPlugin.scala
@@ -5,7 +5,8 @@ import spinal.lib._
 import spinal.lib.misc.pipeline._
 import spinal.lib.misc.plugin.{Plugin, PluginHost}
 import spinal.core.fiber.Retainer
-import transputer.{Opcode, Global}
+import transputer.Opcode
+import transputer.Global
 import transputer.plugins.{ChannelSrv, ChannelTxCmd, LinkBusSrv, LinkBusArbiterSrv}
 import transputer.plugins.schedule.SchedSrv
 import transputer.plugins.fpu.{FpuSrv, FpOp}

--- a/src/main/scala/transputer/plugins/fetch/FetchPlugin.scala
+++ b/src/main/scala/transputer/plugins/fetch/FetchPlugin.scala
@@ -6,7 +6,8 @@ import spinal.lib.misc.plugin.{PluginHost, FiberPlugin, Plugin}
 import spinal.lib.misc.pipeline._
 import spinal.lib.bus.bmb.{Bmb, BmbParameter, BmbAccessParameter, BmbQueue, BmbDownSizerBridge}
 import spinal.core.fiber.Retainer
-import transputer.{Global, Transputer}
+import transputer.Global
+import transputer.Transputer
 import transputer.plugins.SystemBusSrv
 import transputer.plugins.registers.RegfileSrv
 import transputer.plugins.registers.RegName

--- a/src/main/scala/transputer/plugins/fpu/FpuPlugin.scala
+++ b/src/main/scala/transputer/plugins/fpu/FpuPlugin.scala
@@ -13,7 +13,8 @@ import spinal.lib.bus.bmb.{
   BmbUnburstify,
   BmbDownSizerBridge
 }
-import transputer.{Global, Transputer, Opcode}
+import transputer.Global
+import transputer.{Transputer, Opcode}
 import transputer.plugins.SystemBusSrv
 import transputer.plugins.registers.RegfileSrv
 import transputer.plugins.registers.RegName

--- a/src/main/scala/transputer/plugins/grouper/InstrGrouperPlugin.scala
+++ b/src/main/scala/transputer/plugins/grouper/InstrGrouperPlugin.scala
@@ -5,7 +5,8 @@ import spinal.lib._
 import spinal.lib.misc.plugin.{PluginHost, FiberPlugin, Plugin}
 import spinal.lib.misc.pipeline._
 import spinal.core.fiber.Retainer
-import transputer.{Global, Opcode}
+import transputer.Global
+import transputer.Opcode
 import transputer.plugins.registers.RegfileSrv
 import transputer.plugins.Fetch
 import transputer.plugins.registers.RegName

--- a/src/main/scala/transputer/plugins/mmu/MemoryManagementPlugin.scala
+++ b/src/main/scala/transputer/plugins/mmu/MemoryManagementPlugin.scala
@@ -12,7 +12,8 @@ import transputer.plugins.{TrapHandlerSrv, ConfigAccessSrv, AddressTranslationSr
 import transputer.plugins.registers.RegfileSrv
 import transputer.plugins.pipeline.PipelineStageSrv
 import transputer.plugins.registers.RegName
-import transputer.{Global, Transputer}
+import transputer.Global
+import transputer.Transputer
 
 class MemoryManagementPlugin extends FiberPlugin {
   val version = "MemoryManagementPlugin v1.5"

--- a/src/main/scala/transputer/plugins/pipeline/PipelineBuilderPlugin.scala
+++ b/src/main/scala/transputer/plugins/pipeline/PipelineBuilderPlugin.scala
@@ -4,7 +4,8 @@ import spinal.core._
 import spinal.lib.misc.plugin.{PluginHost, FiberPlugin}
 import spinal.lib.misc.pipeline._
 import spinal.core.fiber.Retainer
-import transputer.{Global, Transputer}
+import transputer.Global
+import transputer.Transputer
 import transputer.plugins.pipeline.PipelineStageSrv
 
 class PipelineBuilderPlugin extends FiberPlugin {

--- a/src/main/scala/transputer/plugins/stack/StackPlugin.scala
+++ b/src/main/scala/transputer/plugins/stack/StackPlugin.scala
@@ -5,7 +5,8 @@ import spinal.core.fiber.Retainer
 import spinal.lib._
 import spinal.lib.misc.plugin.{FiberPlugin, Plugin}
 import spinal.lib.bus.bmb.{Bmb, BmbParameter, BmbAccessParameter, BmbDownSizerBridge, BmbUnburstify}
-import transputer.{Global, Transputer}
+import transputer.Global
+import transputer.Transputer
 import transputer.plugins.SystemBusSrv
 import transputer.plugins.registers.RegfileSrv
 import transputer.plugins.registers.RegName


### PR DESCRIPTION
### What & Why
- revert to plain `transputer.Global` imports in plugins

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test` *(fails: compilation errors in WorkspaceCachePlugin)*
- [ ] `sbt "runMain transputer.Generate"` *(fails: compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851aec94ef48325b9e247b02b3e8cfe