### PR TITLE
Add barebones Transputer test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,28 +54,12 @@ lazy val transputer = (project in file("."))
         "Generate.scala",
         "Service.scala",
         "pipeline/Service.scala",
-        "registers/Service.scala",
-        "registers/RegFilePlugin.scala",
-        "fpu/VCU.scala",
-        "fpu/Service.scala",
-        "fpu/Opcodes.scala",
-        "fpu/Adder.scala",
-        "fpu/Multiplier.scala",
-        "fpu/DivRoot.scala",
-        "fpu/RangeReducer.scala",
-        "fpu/FpuPlugin.scala",
-        "fpu/Utils.scala",
         "pipeline/PipelinePlugin.scala",
         "pipeline/PipelineBuilderPlugin.scala",
         "TransputerPlugin.scala",
         "fetch/FetchPlugin.scala",
-        "grouper/InstrGrouperPlugin.scala",
-        "decode/PrimaryInstrPlugin.scala",
-        "execute/SecondaryInstrPlugin.scala",
-        "mmu/MemoryManagementPlugin.scala",
-        "stack/StackPlugin.scala",
-        "cache/MainCachePlugin.scala",
-        "cache/WorkspaceCachePlugin.scala"
+        "registers/Service.scala",
+        "registers/RegFilePlugin.scala"
       )
       val srcDir = (Compile / scalaSource).value
       val selected = (srcDir ** "*.scala").get.filter(f =>
@@ -97,6 +81,7 @@ lazy val transputer = (project in file("."))
         "TestPlugins.scala",
         "FpOpcodeSpec.scala",
         "FpuOpcodeSpec.scala"
+        ,"TransputerBarebonesSpec.scala"
       )
       keep.flatMap(p => (srcDir ** p).get)
     },

--- a/src/test/scala/transputer/TransputerBarebonesSpec.scala
+++ b/src/test/scala/transputer/TransputerBarebonesSpec.scala
@@ -1,0 +1,19 @@
+package transputer
+
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core._
+import transputer.plugins.transputer.TransputerPlugin
+import transputer.plugins.pipeline.{PipelinePlugin, PipelineBuilderPlugin}
+import transputer.plugins.fetch.FetchPlugin
+
+class TransputerBarebonesSpec extends AnyFunSuite {
+  test("minimal plugin stack generates verilog") {
+    val plugins = Seq(
+      new TransputerPlugin,
+      new PipelinePlugin,
+      new FetchPlugin,
+      new PipelineBuilderPlugin
+    )
+    SpinalVerilog(Transputer(plugins))
+  }
+}


### PR DESCRIPTION
### What & Why
- added unit test for minimal Transputer plugin stack
- adjusted build.sbt plugin lists to compile only minimal sources

### Validation
- [ ] sbt scalafmtAll *(failed: task produced no output)*
- [ ] sbt test *(failed to compile FetchPlugin)*
- [ ] sbt "runMain transputer.Generate" *(failed to compile FetchPlugin)*

------
https://chatgpt.com/codex/tasks/task_e_6851aedcf3b8832589e3aa4b742958c3