### PR TITLE
Fix FPU plugin test host

### DIFF
--- a/src/test/scala/transputer/FpuPluginSpec.scala
+++ b/src/test/scala/transputer/FpuPluginSpec.scala
@@ -20,10 +20,11 @@ class FpuDut extends Component {
   }
 
   // Build minimal plugin stack with mock trap handler
-  val host = new PluginHost
   val plugins = Transputer.unitPlugins() ++ Seq(new DummyTrapPlugin, new FpuPlugin)
-  PluginHost(host).on(Database(Transputer.defaultDatabase()).on(Transputer(plugins)))
-
+  val core = PluginHost.on {
+    Database(Transputer.defaultDatabase()).on(Transputer(plugins))
+  }
+  val host = core.host
   val fpuService = host[FpuService]
   val ctrl = host[FpuControlService]
 


### PR DESCRIPTION
### What & Why
- fix PluginHost usage in `FpuPluginSpec`
- ensure FPU services are queried from the transputer host

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test` *(fails: compilation errors)*


------
https://chatgpt.com/codex/tasks/task_e_685745980ad483258608bda28424d918