### PR TITLE
Fix FpuBusySpec counter and enable hello world test

### DIFF
--- a/src/main/scala/transputer/plugins/Service.scala
+++ b/src/main/scala/transputer/plugins/Service.scala
@@ -28,22 +28,22 @@ trait SystemBusService {
 }
 
 trait DataBusService {
-  def rdCmd: Flow[transputer.MemReadCmd]
+  def rdCmd: Flow[_root_.transputer.MemReadCmd]
   def rdRsp: Flow[Bits]
-  def wrCmd: Flow[transputer.MemWriteCmd]
+  def wrCmd: Flow[_root_.transputer.MemWriteCmd]
 }
 
 trait LinkBusService {
-  def rdCmd: Flow[transputer.MemReadCmd]
+  def rdCmd: Flow[_root_.transputer.MemReadCmd]
   def rdRsp: Flow[Bits]
-  def wrCmd: Flow[transputer.MemWriteCmd]
+  def wrCmd: Flow[_root_.transputer.MemWriteCmd]
 }
 
 trait LinkBusArbiterService {
-  def exeRd: Flow[transputer.MemReadCmd]
-  def exeWr: Flow[transputer.MemWriteCmd]
-  def chanRd: Flow[transputer.MemReadCmd]
-  def chanWr: Flow[transputer.MemWriteCmd]
+  def exeRd: Flow[_root_.transputer.MemReadCmd]
+  def exeWr: Flow[_root_.transputer.MemWriteCmd]
+  def chanRd: Flow[_root_.transputer.MemReadCmd]
+  def chanWr: Flow[_root_.transputer.MemWriteCmd]
 }
 
 case class ChannelTxCmd() extends Bundle {
@@ -74,4 +74,9 @@ trait ChannelPinsService {
 
 trait ChannelDmaService {
   def cmd: Stream[ChannelTxCmd]
+}
+
+trait MemAccessService {
+  def rom: Mem[UInt]
+  def ram: Mem[UInt]
 }

--- a/src/test/scala/transputer/FpuBusySpec.scala
+++ b/src/test/scala/transputer/FpuBusySpec.scala
@@ -13,7 +13,7 @@ class BusyDut extends Component {
   val counter = Reg(UInt(10 bits)) init (0)
 
   when(io.start) {
-    counter := io.cycles
+    counter := io.cycles + 1
   } elsewhen (counter =/= 0) {
     counter := counter - 1
   }

--- a/src/test/scala/transputer/HelloWorldSpec.scala
+++ b/src/test/scala/transputer/HelloWorldSpec.scala
@@ -10,7 +10,43 @@ import transputer.plugins.timers.TimerPlugin
 import transputer.plugins.grouper.GrouperPlugin
 
 class HelloWorldSpec extends AnyFunSuite {
-  ignore("ROM program prints hello world") {
+  // Minimal memory service for ROM/RAM access
+  trait MemAccessService {
+    def rom: Mem[UInt]
+    def ram: Mem[UInt]
+  }
+
+  // Simple on-chip memory plugin used by this test
+  class MemoryPlugin(romInit: Seq[BigInt] = Seq()) extends FiberPlugin {
+    private var _rom: Mem[UInt] = null
+    private var _ram: Mem[UInt] = null
+    during setup new Area {
+      _rom = Mem(UInt(Global.WORD_BITS bits), Global.RomWords)
+      for ((v, i) <- romInit.zipWithIndex if i < _rom.wordCount) {
+        _rom(i) init v
+      }
+      _ram = Mem(UInt(Global.WORD_BITS bits), Global.RamWords)
+      addService(new MemAccessService {
+        override def rom: Mem[UInt] = _rom
+        override def ram: Mem[UInt] = _ram
+      })
+    }
+    during build new Area {}
+  }
+
+  // Simple link plugin exposing ChannelPinsService
+  class ChannelPlugin extends FiberPlugin {
+    private var pinsReg: ChannelPins = null
+    during setup new Area {
+      pinsReg = ChannelPins(Global.LinkCount)
+      pinsReg.in.foreach(_.setIdle())
+      pinsReg.out.foreach(_.setIdle())
+      addService(new ChannelPinsService { def pins: ChannelPins = pinsReg })
+    }
+    during build new Area {}
+  }
+
+  test("ROM program prints hello world") {
     SimConfig
       .compile {
         val host = new PluginHost


### PR DESCRIPTION
### What & Why
- fixed busy counter to account for start cycle
- enabled HelloWorldSpec with embedded MemoryPlugin and ChannelPlugin stubs

### Validation
- [x] `sbt scalafmtAll`
- [ ] `sbt test`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68574bbfc42083258b5a7e28cff84943