### PR TITLE
Implement pipeline builder and doc synthesis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,11 @@ jobs:
         run: sbt scalafmtAll
       - name: test
         run: sbt test
+      - name: Upload simulation logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-logs
+          path: simWorkspace
       - name: verilog
         run: sbt "runMain transputer.Generate"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Transputer Core
 
+[![CI](https://github.com/agentdavo/t800/actions/workflows/ci.yml/badge.svg)](https://github.com/agentdavo/t800/actions/workflows/ci.yml)
+
 *(rev 2025-06-17 – includes plugin & pipeline details)*
 
 ---
@@ -131,6 +133,15 @@ sbt "runMain transputer.Generate --word-width 32 --link-count 4 --fpu true"
 --link-count    Number of communication links
 --fpu           Enable or disable the floating-point unit (Generate.scala flag)
 ```
+
+---
+
+## Synthesis
+
+Run `sbt synth` to generate a bitstream for Lattice ECP5 targets. The task calls
+`gen/scripts/synth.tcl`, which expects a constraint LPF and device string. The
+default setup uses `gen/constraints/ecp5.lpf` and `LFE5U-45F`. Ensure
+`nextpnr-ecp5` and `trellis` are installed as shown in the CI workflow.
 
 ---
 

--- a/gen/scripts/synth.tcl
+++ b/gen/scripts/synth.tcl
@@ -1,7 +1,7 @@
 #!/usr/bin/env tclsh
 # Enhanced ECP5 synthesis script for Yosys + nextpnr-ecp5
 # Usage: tclsh synth.tcl <constraints.lpf> <device>
-# Example device: LFE5U-45F
+# Example: tclsh synth.tcl gen/constraints/ecp5.lpf LFE5U-45F
 # Notes: Assumes Transputer.v is in gen/src/verilog
 
 # Retrieve command-line arguments

--- a/src/test/scala/transputer/FpuOpcodeSpec.scala
+++ b/src/test/scala/transputer/FpuOpcodeSpec.scala
@@ -3,9 +3,32 @@ package transputer
 import spinal.core._
 import spinal.core.sim._
 import org.scalatest.funsuite.AnyFunSuite
-import spinal.lib.misc.plugin.PluginHost
+import spinal.lib.misc.plugin.{PluginHost, FiberPlugin, Plugin}
 import spinal.lib.misc.database.Database
 import transputer.plugins.fpu._
+import transputer.plugins.pipeline.{PipelinePlugin, PipelineBuilderPlugin}
+import transputer.plugins.transputer.TransputerPlugin
+import transputer.plugins.registers.{RegFilePlugin, RegfileService, RegName, TransputerRegFileSpec}
+
+/** Simple register file storing only Areg for comparison tests. */
+class DummyRegFilePlugin extends FiberPlugin with RegfileService {
+  val areg = Reg(Bits(64 bits)) init 0
+  override def rfSpec = TransputerRegFileSpec()
+  override def getPhysicalDepth = 1
+  override def writeLatency = 0
+  override def readLatency = 0
+  override def read(reg: RegName.C, pid: UInt, shadow: Boolean): Bits =
+    if (reg == RegName.Areg) areg else B(0, 64 bits)
+  override def write(reg: RegName.C, data: Bits, pid: UInt, shadow: Boolean): Unit =
+    if (reg == RegName.Areg) areg := data.resized
+  override def readShadow(reg: RegName.C, pid: UInt): Bits = read(reg, pid, false)
+  override def writeShadow(reg: RegName.C, data: Bits, pid: UInt): Unit =
+    write(reg, data, pid, false)
+  override def readStatusBit(f: StatusRegBits => Bool, pid: UInt, shadow: Boolean) = False
+  override def writeStatusBit(f: StatusRegBits => Bool, v: Bool, pid: UInt, shadow: Boolean) {}
+  override def copyToShadow(pid: UInt) {}
+  override def restoreFromShadow(pid: UInt) {}
+}
 
 /** Execute FPU opcodes using their raw byte encoding. */
 class FpuOpcodeDut extends Component {
@@ -20,7 +43,14 @@ class FpuOpcodeDut extends Component {
   }
 
   val host = new PluginHost
-  val plugins = Transputer.unitPlugins() ++ Seq(new DummyTrapPlugin, new FpuPlugin)
+  val plugins = Seq(
+    new TransputerPlugin,
+    new DummyRegFilePlugin,
+    new PipelinePlugin,
+    new PipelineBuilderPlugin,
+    new DummyTrapPlugin,
+    new FpuPlugin
+  )
   PluginHost(host).on(Database(Transputer.defaultDatabase()).on(Transputer(plugins)))
 
   val fpuService = host[FpuService]
@@ -52,12 +82,53 @@ class FpuOpcodeSpec extends AnyFunSuite {
     res
   }
 
+  private def runSingle(opc: Int, a: Float): Double = {
+    var res = 0.0
+    SimConfig.compile(new FpuOpcodeDut).doSim { dut =>
+      dut.clockDomain.forkStimulus(10)
+      dut.io.cmdValid #= true
+      dut.io.opcode #= opc
+      dut.io.a #= BigInt(java.lang.Float.floatToRawIntBits(a)) & BigInt("ffffffff", 16)
+      dut.io.b #= 0
+      dut.io.rounding #= 0
+      dut.clockDomain.waitSampling()
+      res = java.lang.Double.longBitsToDouble(dut.io.rsp.toLong)
+    }
+    res
+  }
+
   test("FPLDNLSN loads 1.0") {
     assert(math.abs(run(0x8e, 1.0) - 1.0) < 1e-6)
   }
 
   test("FPDIV divides 4.0 / 2.0") {
     assert(math.abs(run(0x8c, 4.0, 2.0) - 2.0) < 1e-6)
+  }
+
+  test("FPADD adds numbers") {
+    assert(math.abs(run(0x87, 1.5, 2.0) - 3.5) < 1e-6)
+  }
+
+  test("FPMUL multiplies numbers") {
+    assert(math.abs(run(0x8b, 2.0, 3.0) - 6.0) < 1e-6)
+  }
+
+  test("FPGT sets Areg on greater-than") {
+    SimConfig.compile(new FpuOpcodeDut).doSim { dut =>
+      val rf = dut.host[DummyRegFilePlugin]
+      dut.clockDomain.forkStimulus(10)
+      dut.io.cmdValid #= true
+      dut.io.opcode #= 0x94
+      dut.io.a #= BigInt(java.lang.Double.doubleToRawLongBits(2.0))
+      dut.io.b #= BigInt(java.lang.Double.doubleToRawLongBits(1.0))
+      dut.io.rounding #= 0
+      dut.clockDomain.waitSampling()
+      assert(rf.areg.toBigInt == 1)
+    }
+  }
+
+  test("FPR32TOR64 converts single to double") {
+    assert(math.abs(runSingle(0xd7, 1.5f) - 1.5) < 1e-6)
   }
 
   test("FPRN sets rounding mode") {

--- a/src/test/scala/transputer/PipelineBuilderPluginSpec.scala
+++ b/src/test/scala/transputer/PipelineBuilderPluginSpec.scala
@@ -1,0 +1,42 @@
+package transputer
+
+import spinal.core._
+import spinal.core.sim._
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.lib.misc.plugin.{PluginHost, FiberPlugin, Plugin}
+import spinal.lib.misc.pipeline._
+import transputer.plugins.pipeline.{PipelinePlugin, PipelineBuilderPlugin, PipelineStageService, PipelineService}
+import transputer.plugins.transputer.TransputerPlugin
+import transputer.plugins.registers.RegFilePlugin
+
+/** Simple plugin inserting a link between decode and execute stages. */
+class DummyLinkPlugin extends FiberPlugin with PipelineService {
+  private var links: Seq[Link] = Seq()
+  override def getLinks(): Seq[Link] = links
+
+  during build new Area {
+    implicit val h: PluginHost = host
+    val pipe = Plugin[PipelineStageService]
+    links = Seq(StageLink(pipe.decode.down, pipe.execute.up))
+  }
+}
+
+class PipelineBuilderPluginSpec extends AnyFunSuite {
+  test("builder collects stage links") {
+    SimConfig.compile {
+      val host = new PluginHost
+      val plugins = Seq(
+        new TransputerPlugin,
+        new RegFilePlugin,
+        new PipelinePlugin,
+        new DummyLinkPlugin,
+        new PipelineBuilderPlugin
+      )
+      PluginHost(host).on(Transputer(plugins))
+    }.doSim { dut =>
+      val builder = dut.host[PipelineBuilderPlugin]
+      assert(builder.buildPipeline().nonEmpty)
+    }
+  }
+}
+


### PR DESCRIPTION
### What & Why
- document FPGA synthesis workflow and add CI badge
- explain synth.tcl arguments
- implement `PipelineBuilderPlugin` and expose build API
- extend opcode tests and add pipeline builder test
- upload sim logs on CI failure

### Validation
- `sbt scalafmtAll`
- `sbt test` *(fails: compile errors)*
- `sbt "runMain transputer.Generate"` *(fails: compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68574c06a36c8325a30155819808b54c