### PR TITLE
[M-1] add FetchPlugin to BareBones

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,11 @@ lazy val transputer = (project in file("."))
             "plugins/transputer/TransputerPlugin.scala",
             "pipeline/PipelinePlugin.scala",
             "pipeline/PipelineBuilderPlugin.scala",
-            "registers/RegFilePlugin.scala"
+            "registers/RegFilePlugin.scala",
+            "plugins/fetch/Service.scala",
+            "plugins/fetch/Fetch.scala",
+            "plugins/fetch/DummyInstrFetchPlugin.scala",
+            "plugins/fetch/FetchPlugin.scala"
           )
         case _ =>
           Set(
@@ -87,7 +91,7 @@ lazy val transputer = (project in file("."))
             "pipeline/PipelinePlugin.scala",
             "pipeline/PipelineBuilderPlugin.scala",
             "TransputerPlugin.scala",
-            "fetch/FetchPlugin.scala",
+            "plugins/fetch/FetchPlugin.scala",
             "grouper/InstrGrouperPlugin.scala",
             "decode/PrimaryInstrPlugin.scala",
             "execute/SecondaryInstrPlugin.scala",

--- a/src/main/scala/transputer/Transputer.scala
+++ b/src/main/scala/transputer/Transputer.scala
@@ -8,6 +8,7 @@ import spinal.lib.bus.bmb.{Bmb, BmbParameter}
 import transputer.plugins.transputer.TransputerPlugin
 import transputer.plugins.pipeline.{PipelinePlugin, PipelineBuilderPlugin}
 import transputer.plugins.registers.RegFilePlugin
+import transputer.plugins.fetch.{DummyInstrFetchPlugin, FetchPlugin}
 import transputer.plugins.SystemBusService
 
 object Transputer {
@@ -33,6 +34,8 @@ object Transputer {
       new TransputerPlugin,
       new RegFilePlugin,
       new PipelinePlugin,
+      new DummyInstrFetchPlugin,
+      new FetchPlugin,
       new PipelineBuilderPlugin
     )
 

--- a/src/main/scala/transputer/barebones/BareBonesParamStub.scala
+++ b/src/main/scala/transputer/barebones/BareBonesParamStub.scala
@@ -15,6 +15,8 @@ case class Param() {
 
     plugins += new transputer.plugins.pipeline.PipelinePlugin
     plugins += new transputer.plugins.registers.RegFilePlugin
+    plugins += new transputer.plugins.fetch.DummyInstrFetchPlugin
+    plugins += new transputer.plugins.fetch.FetchPlugin
     plugins += new transputer.plugins.pipeline.PipelineBuilderPlugin
   }
 }

--- a/src/main/scala/transputer/plugins/fetch/DummyInstrFetchPlugin.scala
+++ b/src/main/scala/transputer/plugins/fetch/DummyInstrFetchPlugin.scala
@@ -3,13 +3,11 @@ package transputer.plugins.fetch
 import spinal.core._
 import spinal.lib._
 import spinal.lib.misc.plugin.FiberPlugin
-import transputer.MemReadCmd
+import transputer.{Global, MemReadCmd}
 import transputer.plugins.fetch.InstrFetchService
 
-/** Simplified instruction fetch plugin used by the BareBones build. */
-class FetchPlugin extends FiberPlugin {
-  setName("fetch")
-
+/** Dummy provider for [[InstrFetchService]] used by the BareBones build. */
+class DummyInstrFetchPlugin extends FiberPlugin {
   private var cmdReg: Flow[MemReadCmd] = null
   private var rspReg: Flow[Bits] = null
 

--- a/src/main/scala/transputer/plugins/fetch/Service.scala
+++ b/src/main/scala/transputer/plugins/fetch/Service.scala
@@ -2,10 +2,10 @@ package transputer.plugins.fetch
 
 import spinal.core._
 import spinal.lib._
-import transputer.Global
+import transputer.{Global, MemReadCmd}
 
 /** Service interface for instruction fetch, integrated with MainCachePlugin. */
 trait InstrFetchService {
-  def cmd: Flow[Global.MemReadCmd] // BMB-based read command
+  def cmd: Flow[MemReadCmd] // BMB-based read command
   def rsp: Flow[Bits] // Response with opcodes
 }

--- a/src/test/scala/transputer/BareBonesSpec.scala
+++ b/src/test/scala/transputer/BareBonesSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import transputer.plugins.pipeline.{PipelinePlugin, PipelineBuilderPlugin}
 import transputer.plugins.transputer.TransputerPlugin
 import transputer.plugins.registers.RegFilePlugin
+import transputer.plugins.fetch.{DummyInstrFetchPlugin, FetchPlugin}
 
 /** Basic sanity checks for the BareBones core. */
 class BareBonesSpec extends AnyFunSuite {
@@ -19,6 +20,8 @@ class BareBonesSpec extends AnyFunSuite {
       assert(dut.core.host[TransputerPlugin] != null)
       assert(dut.core.host[RegFilePlugin] != null)
       assert(dut.core.host[PipelinePlugin] != null)
+      assert(dut.core.host[DummyInstrFetchPlugin] != null)
+      assert(dut.core.host[FetchPlugin] != null)
       val builder = dut.core.host[PipelineBuilderPlugin]
       assert(builder.buildPipeline().isEmpty)
     }


### PR DESCRIPTION
### What & Why
- fixed FetchPlugin to directly provide InstrFetchService in barebones mode
- allowed fetch sources under `plugins/fetch/` to compile in minimal build

### Validation
- [x] sbt scalafmtAll
- [ ] sbt test *(failed: compile errors in SecondaryInstrPlugin)*
- [x] sbt bareBonesTest

------
https://chatgpt.com/codex/tasks/task_e_68582293ac048325b7bb8cc52712b005