### PR TITLE
Add Grouper and primary instruction plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,9 @@ lazy val transputer = (project in file("."))
             "plugins/fetch/Service.scala",
             "plugins/fetch/Fetch.scala",
             "plugins/fetch/DummyInstrFetchPlugin.scala",
-            "plugins/fetch/FetchPlugin.scala"
+            "plugins/fetch/FetchPlugin.scala",
+            "grouper/InstrGrouperPlugin.scala",
+            "decode/PrimaryInstrPlugin.scala"
           )
         case _ =>
           Set(

--- a/src/main/scala/transputer/barebones/BareBonesParamStub.scala
+++ b/src/main/scala/transputer/barebones/BareBonesParamStub.scala
@@ -18,5 +18,7 @@ case class Param() {
     plugins += new transputer.plugins.fetch.DummyInstrFetchPlugin
     plugins += new transputer.plugins.fetch.FetchPlugin
     plugins += new transputer.plugins.pipeline.PipelineBuilderPlugin
+    plugins += new transputer.plugins.grouper.GrouperPlugin
+    plugins += new transputer.plugins.decode.PrimaryInstrPlugin
   }
 }

--- a/src/main/scala/transputer/memory/BmbOnChipRamGenerator.scala
+++ b/src/main/scala/transputer/memory/BmbOnChipRamGenerator.scala
@@ -1,0 +1,45 @@
+package transputer.memory
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.bmb._
+
+/** Generator for a BMB on-chip RAM or ROM mapped at a fixed address.
+  *
+  * Usage example:
+  * {{
+  *   implicit val interconnect = BmbInterconnectGenerator(ClockDomain.current)
+  *   val ramA = BmbOnChipRamGenerator(0x80000000L)
+  *   ramA.size := 4096
+  *   ramA.hexInit := "prog.hex"
+  * }}
+  */
+case class BmbOnChipRamGenerator(address: Handle[BigInt] = Unset)
+                                 (implicit interconnect: BmbInterconnectGenerator)
+    extends Area {
+  val size      = Handle[BigInt]
+  var hexOffset = BigInt(0)
+  val hexInit   = Handle[String]
+  val source    = Handle[BmbAccessCapabilities]
+  val requirements = Handle[BmbAccessParameter]
+  val ctrl      = Handle(logic.io.bus)
+
+  interconnect.addSlave(
+    accessSource       = source,
+    accessCapabilities = Handle(BmbOnChipRam.busCapabilities(size, source.dataWidth)),
+    accessRequirements = requirements,
+    bus                = ctrl,
+    mapping            = Handle(SizeMapping(address, BigInt(1) << log2Up(size)))
+  )
+
+  val logic = Handle(
+    BmbOnChipRam(
+      p         = requirements.toBmbParameter(),
+      size      = size,
+      hexOffset = address.get + hexOffset,
+      hexInit   = hexInit
+    )
+  )
+
+  sexport[BigInt](size, size.toInt)
+}


### PR DESCRIPTION
### What & Why
- include Grouper and PrimaryInstr plugins in BareBones configuration
- ensure build includes plugin source files for the BareBones build configuration in `build.sbt`
- add BmbOnChipRamGenerator helper for mapping ROM/RAM blocks on BMB interconnects

### Validation
- [x] sbt scalafmtAll
- [ ] sbt test
- [ ] sbt "runMain transputer.Generate"

Compilation failed during tests and Verilog generation.

------
https://chatgpt.com/codex/tasks/task_e_685841e1346483258cf8d3053da28859